### PR TITLE
Update tokio dependency to 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ edition = "2018"
 futures = "0.3.7"
 libc = "0.2.77"
 socket2 = { version = "0.3.15", features = ["unix", "pair"] }
-tokio = { version = "0.3.2", features = ["net"] }
+tokio = { version = "1.0", features = ["net"] }
 
 [dev-dependencies]
 assert2 = "0.3.3"
-tokio = { version = "0.3.2", features = ["rt", "macros", "time"] }
+tokio = { version = "1.0", features = ["rt", "macros", "time"] }
 tempfile = "3.1.0"


### PR DESCRIPTION
This patch enables usage of this crate with Tokio 1.0.