### PR TITLE
Fix hangs by using the `try_io` API

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -305,14 +305,13 @@ fn check_returned_size(ret: isize) -> std::io::Result<usize> {
 
 /// Send data on the socket to the connected peer without blocking.
 pub(crate) fn poll_send(socket: &UnixSeqpacket, cx: &mut Context, buffer: &[u8]) -> Poll<std::io::Result<usize>> {
-	let mut ready_guard = ready!(socket.io.poll_write_ready(cx)?);
+	loop {
+		let mut ready_guard = ready!(socket.io.poll_write_ready(cx)?);
 
-	match socket.io.get_ref().send(buffer) {
-		Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-			ready_guard.clear_ready();
-			Poll::Pending
-		},
-		x => Poll::Ready(x),
+		match ready_guard.try_io(|inner| inner.get_ref().send(buffer)) {
+			Ok(result) => return Poll::Ready(result),
+			Err(_would_block) => continue,
+		}
 	}
 }
 
@@ -332,27 +331,23 @@ pub(crate) fn poll_send_vectored_with_ancillary(
 	buffer: &[IoSlice],
 	ancillary: &mut SocketAncillary,
 ) -> Poll<std::io::Result<usize>> {
-	let mut ready_guard = ready!(socket.io.poll_write_ready(cx)?);
-
-	match send_msg(socket.io.get_ref(), buffer, ancillary) {
-		Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-			ready_guard.clear_ready();
-			Poll::Pending
-		},
-		x => Poll::Ready(x),
+	loop {
+		let mut ready_guard = ready!(socket.io.poll_write_ready(cx)?);
+		match ready_guard.try_io(|inner| send_msg(inner.get_ref(), buffer, ancillary)) {
+			Ok(result) => return Poll::Ready(result),
+			Err(_would_block) => continue,
+		}
 	}
 }
 
 /// Receive data on the socket from the connected peer without blocking.
 pub(crate) fn poll_recv(socket: &UnixSeqpacket, cx: &mut Context, buffer: &mut [u8]) -> Poll<std::io::Result<usize>> {
-	let mut ready_guard = ready!(socket.io.poll_read_ready(cx)?);
-
-	match socket.io.get_ref().recv(buffer) {
-		Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-			ready_guard.clear_ready();
-			Poll::Pending
-		},
-		x => Poll::Ready(x),
+	loop {
+		let mut ready_guard = ready!(socket.io.poll_read_ready(cx)?);
+		match ready_guard.try_io(|inner| inner.get_ref().recv(buffer)) {
+			Ok(result) => return Poll::Ready(result),
+			Err(_would_block) => continue,
+		}
 	}
 }
 
@@ -372,13 +367,12 @@ pub(crate) fn poll_recv_vectored_with_ancillary(
 	buffer: &mut [IoSliceMut],
 	ancillary: &mut SocketAncillary,
 ) -> Poll<std::io::Result<usize>> {
-	let mut ready_guard = ready!(socket.io.poll_read_ready(cx)?);
+	loop {
+		let mut ready_guard = ready!(socket.io.poll_read_ready(cx)?);
 
-	match recv_msg(socket.io.get_ref(), buffer, ancillary) {
-		Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-			ready_guard.clear_ready();
-			Poll::Pending
-		},
-		x => Poll::Ready(x),
+		match ready_guard.try_io(|inner| recv_msg(inner.get_ref(), buffer, ancillary)) {
+			Ok(result) => return Poll::Ready(result),
+			Err(_would_block) => continue,
+		}
 	}
 }


### PR DESCRIPTION
The new test case included in this change would reliably hang; at
least on Linux with `epoll`. I have the hunch that this may be related
to spurious wakeups and/or everything being edge-triggered now.

Adapting the code to use looping, and the `try_io` helper method, as
illustrated in the current documentation for `AsyncFd`, seems to fix
the hangs.