### PR TITLE
Fix sending ancillary data on non-Linux platforms

### DIFF
--- a/src/ancillary.rs
+++ b/src/ancillary.rs
@@ -56,7 +56,7 @@ fn add_to_ancillary_data<T>(
 
 		let mut cmsg = libc::CMSG_FIRSTHDR(&msg);
 		let mut previous_cmsg = cmsg;
-		while !cmsg.is_null() {
+		while !cmsg.is_null() && (*cmsg).cmsg_len > 0 {
 			previous_cmsg = cmsg;
 			cmsg = libc::CMSG_NXTHDR(&msg, cmsg);
 		}


### PR DESCRIPTION
On Linux, CMSG_NXTHDR returns NULL if the next cmsg has a length of
zero.  However, CMSG_NXTHDR does not do that on any other platform, even
Android.  So for portability, the caller should always check it.