### PR TITLE
Implement Into<OwnedFd> and try_connect function

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -65,6 +65,19 @@ impl UnixSeqpacket {
 		Ok(socket)
 	}
 
+	/// Connect to a socket without checking for the writeable flag
+	pub fn try_connect<P: AsRef<Path>>(address: P) -> std::io::Result<Self> {
+		let socket = sys::local_seqpacket_socket()?;
+		if let Err(e) = sys::connect(&socket, address) {
+			if e.kind() != std::io::ErrorKind::WouldBlock {
+				return Err(e);
+			}
+		}
+
+		let socket = Self::new(socket)?;
+		Ok(socket)
+	}
+
 	/// Create a pair of connected seqpacket sockets.
 	pub fn pair() -> std::io::Result<(Self, Self)> {
 		let (a, b) = sys::local_seqpacket_pair()?;

--- a/tests/listener.rs
+++ b/tests/listener.rs
@@ -33,3 +33,36 @@ async fn unix_seqpacket_listener() {
 
 	assert!(let Ok(()) = server_task.await);
 }
+
+#[tokio::test]
+async fn unix_seqpacket_try_connect_listener() {
+	let dir = tempdir().unwrap();
+	let path = dir.path().join("listener.sock");
+
+	let server_task = tokio::spawn({
+		let_assert!(Ok(mut listener) = UnixSeqpacketListener::bind(&path));
+		let_assert!(Ok(local_address) = listener.local_addr());
+		assert!(local_address == path);
+		async move {
+			for _ in 0..2 {
+				let_assert!(Ok(peer) = listener.accept().await);
+				assert!(let Ok(_) = peer.send(b"Hello!").await);
+				let mut buf = [0u8; 128];
+				let_assert!(Ok(len) = peer.recv(&mut buf).await);
+				assert!(&buf[..len] == b"Goodbye!");
+			}
+		}
+	});
+
+	let mut i = 0;
+	while i < 2 {
+		let_assert!(Ok(peer) = UnixSeqpacket::try_connect(&path));
+		let mut buf = [0u8; 128];
+		let_assert!(Ok(len) = peer.recv(&mut buf).await);
+		assert!(&buf[..len] == b"Hello!");
+		assert!(let Ok(_) = peer.send(b"Goodbye!").await);
+		i += 1;
+	}
+
+	assert!(let Ok(()) = server_task.await);
+}


### PR DESCRIPTION
The non-async try_connect function may be useful when you need a requirement for connection timeout and don't want to change the callers to async.