### PR TITLE
Update FreeBSD CI image to 12.4

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image: freebsd-12-3-release-amd64
+  image: freebsd-12-4-release-amd64
 
 task:
   name: FreeBSD (stable)


### PR DESCRIPTION
12.3 will be EoL in a few more weeks.