### PR TITLE
Update FreeBSD CI image

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image: freebsd-12-4-release-amd64
+  image: freebsd-13-2-release-amd64
 
 task:
   name: FreeBSD (stable)


### PR DESCRIPTION
FreeBSD 12.4 will be EoL at the end of the month.  Update CI to the oldest supported release.