### PR TITLE
Always preserve message boundaries when sending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+Unreleased - ReleaseDate:
+  * Always preserve record boundaries when sending on a `UnixSeqpacket` socket.
+
 v0.8.0 - 2024-11-10:
   * Do not add a trailing null byte to abstract namespace socket paths on Linux and Android in `bind()` and `connect()`.
   * Do not strip a traling null byte from abstract namespace socket paths on Linux and Android in `local_addr()`.

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -8,7 +8,7 @@ use crate::ancillary::{AncillaryMessageReader, AncillaryMessageWriter};
 
 const SOCKET_FLAGS: c_int = libc::SOCK_CLOEXEC | libc::SOCK_NONBLOCK;
 const SOCKET_TYPE: c_int = libc::SOCK_SEQPACKET | SOCKET_FLAGS;
-const SEND_MSG_DEFAULT_FLAGS: c_int = libc::MSG_NOSIGNAL;
+const SEND_MSG_DEFAULT_FLAGS: c_int = libc::MSG_NOSIGNAL | libc::MSG_EOR;
 
 #[cfg(any(target_os = "illumos", target_os = "solaris"))]
 const RECV_MSG_DEFAULT_FLAGS: c_int = libc::MSG_NOSIGNAL;

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -12,6 +12,22 @@ async fn send_recv() {
 	assert!(&buffer[..12] == b"Hello world!");
 }
 
+/// Record boundaries should be preserved
+#[tokio::test]
+async fn record_boundaries() {
+	let_assert!(Ok((a, b)) = UnixSeqpacket::pair());
+	assert!(let Ok(12) = a.send(b"Hello world!").await);
+	assert!(let Ok(12) = a.send(b"Byebye world").await);
+
+	// Having sent two messages, we recv should return twice, with only a single message each
+	// time.
+	let mut buffer = [0u8; 128];
+	assert!(let Ok(12) = b.recv(&mut buffer).await);
+	assert!(&buffer[..12] == b"Hello world!");
+	assert!(let Ok(12) = b.recv(&mut buffer).await);
+	assert!(&buffer[..12] == b"Byebye world");
+}
+
 /// Test a send and receive call where the send wakes the recv task.
 #[test]
 fn send_recv_out_of_order() {


### PR DESCRIPTION
Preserving message boundaries is the key feature of SOCK_SEQPACKET, so there's little reason not to do it.  If one doesn't want to preserve message boundaries, then one may as well use SOCK_STREAM.