### PR TITLE
chore: run rustfmt

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,6 +4,19 @@ on:
   pull_request: { branches: "*" }
 
 jobs:
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: fmt
+      - name: Rustfmt
+        run: cargo fmt --check --all
+
   build_and_test:
     name: Linux
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
         with:
-          components: fmt
+          components: rustfmt
       - name: Rustfmt
         run: cargo fmt --check --all
 

--- a/src/ancillary/mod.rs
+++ b/src/ancillary/mod.rs
@@ -6,7 +6,7 @@ mod reader;
 pub use reader::*;
 
 mod writer;
-pub use writer::{AncillaryMessageWriter, AddControlMessageError};
+pub use writer::{AddControlMessageError, AncillaryMessageWriter};
 
 const FD_SIZE: usize = std::mem::size_of::<BorrowedFd>();
 

--- a/src/ancillary/reader.rs
+++ b/src/ancillary/reader.rs
@@ -1,4 +1,4 @@
-use std::os::fd::{OwnedFd, BorrowedFd};
+use std::os::fd::{BorrowedFd, OwnedFd};
 
 use super::FD_SIZE;
 
@@ -61,7 +61,7 @@ pub enum AncillaryMessage<'a> {
 	Credentials(UnixCredentials<'a>),
 
 	/// Ancillary message uninterpreted data.
-	Other(UnknownMessage<'a>)
+	Other(UnknownMessage<'a>),
 }
 
 /// This enum represent one control message of variable type.
@@ -76,7 +76,7 @@ pub enum OwnedAncillaryMessage<'a> {
 	Credentials(UnixCredentials<'a>),
 
 	/// Ancillary message uninterpreted data.
-	Other(UnknownMessage<'a>)
+	Other(UnknownMessage<'a>),
 }
 
 /// A control message containing borrowed file descriptors.
@@ -165,7 +165,10 @@ impl<'a> AncillaryMessageReader<'a> {
 
 	/// Returns the iterator of the control messages.
 	pub fn messages(&self) -> AncillaryMessages<'_> {
-		AncillaryMessages { buffer: self.buffer, current: None }
+		AncillaryMessages {
+			buffer: self.buffer,
+			current: None,
+		}
 	}
 
 	/// Consume the ancillary message to take ownership of the contained objects (such as file descriptors).
@@ -178,7 +181,10 @@ impl<'a> AncillaryMessageReader<'a> {
 impl Drop for AncillaryMessageReader<'_> {
 	fn drop(&mut self) {
 		if !self.is_empty() {
-			drop(IntoAncillaryMessages { buffer: self.buffer, current: None })
+			drop(IntoAncillaryMessages {
+				buffer: self.buffer,
+				current: None,
+			})
 		}
 	}
 }
@@ -232,7 +238,11 @@ impl<'a> AncillaryMessage<'a> {
 				(libc::SOL_SOCKET, libc::SCM_RIGHTS) => Self::FileDescriptors(FileDescriptors { data }),
 				#[cfg(any(target_os = "android", target_os = "linux", target_os = "netbsd"))]
 				(libc::SOL_SOCKET, super::SCM_CREDENTIALS) => Self::Credentials(UnixCredentials { data }),
-				(cmsg_level, cmsg_type) => Self::Other(UnknownMessage { cmsg_level, cmsg_type, data }),
+				(cmsg_level, cmsg_type) => Self::Other(UnknownMessage {
+					cmsg_level,
+					cmsg_type,
+					data,
+				}),
 			}
 		}
 	}
@@ -295,7 +305,11 @@ impl<'a> OwnedAncillaryMessage<'a> {
 				(libc::SOL_SOCKET, libc::SCM_RIGHTS) => Self::FileDescriptors(OwnedFileDescriptors { data }),
 				#[cfg(any(target_os = "android", target_os = "linux", target_os = "netbsd"))]
 				(libc::SOL_SOCKET, super::SCM_CREDENTIALS) => Self::Credentials(UnixCredentials { data }),
-				(cmsg_level, cmsg_type) => Self::Other(UnknownMessage { cmsg_level, cmsg_type, data }),
+				(cmsg_level, cmsg_type) => Self::Other(UnknownMessage {
+					cmsg_level,
+					cmsg_type,
+					data,
+				}),
 			}
 		}
 	}
@@ -321,9 +335,7 @@ impl<'a> FileDescriptors<'a> {
 		} else {
 			// SAFETY: The memory is valid, and the kernel guaranteed it is a file descriptor.
 			// Additionally, the returned lifetime is linked to the `AncillaryMessageReader` which owns the file descriptor.
-			unsafe {
-				Some(std::ptr::read_unaligned(self.data[index * FD_SIZE..].as_ptr().cast()))
-			}
+			unsafe { Some(std::ptr::read_unaligned(self.data[index * FD_SIZE..].as_ptr().cast())) }
 		}
 	}
 }
@@ -406,8 +418,8 @@ impl<'a> std::iter::ExactSizeIterator for OwnedFileDescriptors<'a> {
 
 #[cfg(any(target_os = "linux", target_os = "android", target_os = "netbsd"))]
 mod unix_creds_impl {
-	use super::UnixCredentials;
 	use super::super::RawScmCreds;
+	use super::UnixCredentials;
 	use crate::UCred;
 
 	impl UnixCredentials<'_> {
@@ -428,9 +440,8 @@ mod unix_creds_impl {
 			} else {
 				// SAFETY: The memory is valid, and the kernel guaranteed it is a credentials struct.
 				// It probably also guarantees alignment, but just in case not, use read_unaligned.
-				let raw: RawScmCreds = unsafe {
-					std::ptr::read_unaligned(self.data.as_ptr().cast::<RawScmCreds>().add(index))
-				};
+				let raw: RawScmCreds =
+					unsafe { std::ptr::read_unaligned(self.data.as_ptr().cast::<RawScmCreds>().add(index)) };
 				Some(UCred::from_scm_creds(raw))
 			}
 		}

--- a/src/ancillary/writer.rs
+++ b/src/ancillary/writer.rs
@@ -107,13 +107,19 @@ impl<'a> AncillaryMessageWriter<'a> {
 	/// }
 	/// ```
 	pub fn add_fds<T>(&mut self, fds: &[T]) -> Result<(), AddControlMessageError>
-		where
-			T: BorrowFd<'a>,
+	where
+		T: BorrowFd<'a>,
 	{
 		use std::os::fd::AsRawFd;
 
 		let byte_len = fds.len() * FD_SIZE;
-		let buffer = reserve_ancillary_data(self.buffer, &mut self.length, byte_len, libc::SOL_SOCKET, libc::SCM_RIGHTS)?;
+		let buffer = reserve_ancillary_data(
+			self.buffer,
+			&mut self.length,
+			byte_len,
+			libc::SOL_SOCKET,
+			libc::SCM_RIGHTS,
+		)?;
 
 		for (i, fd) in fds.iter().enumerate() {
 			let bytes = fd.borrow_fd().as_raw_fd().to_ne_bytes();
@@ -136,7 +142,13 @@ impl<'a> AncillaryMessageWriter<'a> {
 		const ELEM_SIZE: usize = std::mem::size_of::<RawScmCreds>();
 
 		let byte_len = credentials.len() * ELEM_SIZE;
-		let buffer = reserve_ancillary_data(self.buffer, &mut self.length, byte_len, libc::SOL_SOCKET, super::SCM_CREDENTIALS)?;
+		let buffer = reserve_ancillary_data(
+			self.buffer,
+			&mut self.length,
+			byte_len,
+			libc::SOL_SOCKET,
+			super::SCM_CREDENTIALS,
+		)?;
 
 		for (i, cred) in credentials.iter().enumerate() {
 			let raw = &cred.to_scm_creds();
@@ -144,7 +156,11 @@ impl<'a> AncillaryMessageWriter<'a> {
 			// since they come from distinct &mut self and &[SocketCred] references.
 			// The buffer is guaranteed to be large enough by `reserve_ancillary_data`.
 			unsafe {
-				std::ptr::copy_nonoverlapping(raw as *const _ as *const u8, buffer[i * ELEM_SIZE..].as_mut_ptr(), ELEM_SIZE);
+				std::ptr::copy_nonoverlapping(
+					raw as *const _ as *const u8,
+					buffer[i * ELEM_SIZE..].as_mut_ptr(),
+					ELEM_SIZE,
+				);
 			}
 		}
 		Ok(())
@@ -190,13 +206,11 @@ fn reserve_ancillary_data<'a>(
 	cmsg_level: libc::c_int,
 	cmsg_type: libc::c_int,
 ) -> Result<&'a mut [u8], AddControlMessageError> {
-	let byte_len = u32::try_from(byte_len)
-		.map_err(|_| AddControlMessageError(()))?;
+	let byte_len = u32::try_from(byte_len).map_err(|_| AddControlMessageError(()))?;
 
 	unsafe {
 		let additional_space = libc::CMSG_SPACE(byte_len) as usize;
-		let new_length = length.checked_add(additional_space)
-			.ok_or(AddControlMessageError(()))?;
+		let new_length = length.checked_add(additional_space).ok_or(AddControlMessageError(()))?;
 		if new_length > buffer.len() {
 			return Err(AddControlMessageError(()));
 		}

--- a/src/borrow_fd.rs
+++ b/src/borrow_fd.rs
@@ -1,6 +1,6 @@
 //! Utility module for borrowing file descriptors with a specific lifetime.
 
-use std::os::fd::{BorrowedFd, AsFd};
+use std::os::fd::{AsFd, BorrowedFd};
 
 /// Trait for types that can give a [`BorrowedFd<'a>`].
 ///

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -278,10 +278,11 @@ impl UnixSeqpacket {
 		loop {
 			let mut ready_guard = ready!(self.io.poll_read_ready(cx)?);
 
-			let (read, ancillary_reader) = match ready_guard.try_io(|inner| sys::recv_msg(inner.get_ref(), buffer, ancillary_buffer)) {
-				Ok(x) => x?,
-				Err(_would_block) => continue,
-			};
+			let (read, ancillary_reader) =
+				match ready_guard.try_io(|inner| sys::recv_msg(inner.get_ref(), buffer, ancillary_buffer)) {
+					Ok(x) => x?,
+					Err(_would_block) => continue,
+				};
 
 			// SAFETY: We have to work around a borrow checker bug:
 			// It doesn't know that we return in this branch, so the loop terminates.
@@ -312,8 +313,7 @@ impl UnixSeqpacket {
 	/// All calling tasks will try to complete the asynchronous action,
 	/// although the order in which they complete is not guaranteed.
 	pub async fn recv_vectored(&self, buffer: &mut [IoSliceMut<'_>]) -> std::io::Result<usize> {
-		let (read, _ancillary) = self.recv_vectored_with_ancillary(buffer, &mut [])
-			.await?;
+		let (read, _ancillary) = self.recv_vectored_with_ancillary(buffer, &mut []).await?;
 		Ok(read)
 	}
 
@@ -337,10 +337,11 @@ impl UnixSeqpacket {
 		loop {
 			let mut ready_guard = self.io.readable().await?;
 
-			let (read, ancillary_reader) = match ready_guard.try_io(|inner| sys::recv_msg(inner.get_ref(), buffer, ancillary_buffer)) {
-				Ok(x) => x?,
-				Err(_would_block) => continue,
-			};
+			let (read, ancillary_reader) =
+				match ready_guard.try_io(|inner| sys::recv_msg(inner.get_ref(), buffer, ancillary_buffer)) {
+					Ok(x) => x?,
+					Err(_would_block) => continue,
+				};
 
 			// SAFETY: We have to work around a borrow checker bug:
 			// It doesn't know that we return in this branch, so the loop terminates.

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -130,7 +130,11 @@ pub fn send(socket: &FileDesc, buffer: &[u8]) -> std::io::Result<usize> {
 	}
 }
 
-pub fn send_msg(socket: &FileDesc, buffer: &[IoSlice], ancillary: &mut AncillaryMessageWriter) -> std::io::Result<usize> {
+pub fn send_msg(
+	socket: &FileDesc,
+	buffer: &[IoSlice],
+	ancillary: &mut AncillaryMessageWriter,
+) -> std::io::Result<usize> {
 	let control_data = match ancillary.len() {
 		0 => std::ptr::null_mut(),
 		_ => ancillary.buffer.as_mut_ptr() as *mut std::os::raw::c_void,
@@ -201,7 +205,8 @@ pub fn recv_msg<'a>(
 	// This is not a no-op on all platforms.
 	#[allow(clippy::useless_conversion)]
 	{
-		header.msg_controllen = ancillary_buffer.len()
+		header.msg_controllen = ancillary_buffer
+			.len()
 			.try_into()
 			.map_err(|_| std::io::ErrorKind::InvalidInput)?;
 	}

--- a/src/ucred.rs
+++ b/src/ucred.rs
@@ -158,11 +158,7 @@ fn get_peer_cred<T: AsRawFd>(sock: &T) -> std::io::Result<UCred> {
 	let ret = unsafe { getpeereid(raw_fd, uid.as_mut_ptr(), gid.as_mut_ptr()) };
 
 	if ret == 0 {
-		Ok(UCred {
-			uid,
-			gid,
-			pid,
-		})
+		Ok(UCred { uid, gid, pid })
 	} else {
 		Err(std::io::Error::last_os_error())
 	}
@@ -182,11 +178,7 @@ fn get_peer_cred<T: AsRawFd>(sock: &T) -> std::io::Result<UCred> {
 
 			libc::ucred_free(cred);
 
-			Ok(UCred {
-				uid,
-				gid,
-				pid,
-			})
+			Ok(UCred { uid, gid, pid })
 		} else {
 			Err(std::io::Error::last_os_error())
 		}

--- a/tests/abstract_namespace.rs
+++ b/tests/abstract_namespace.rs
@@ -7,8 +7,8 @@ use tokio_seqpacket::{UnixSeqpacket, UnixSeqpacketListener};
 
 #[track_caller]
 fn random_abstract_name(suffix: &str) -> PathBuf {
-	use std::io::Read;
 	use std::ffi::OsString;
+	use std::io::Read;
 	use std::os::unix::ffi::OsStringExt;
 
 	assert!(let Ok(mut urandom) = std::fs::File::open("/dev/urandom"));
@@ -41,10 +41,7 @@ async fn address_without_null_byte() {
 	assert!(let Ok(local_addr) = listener.local_addr());
 	assert!(local_addr == name);
 
-	let (server_socket, client_socket) = tokio::join!(
-		listener.accept(),
-		UnixSeqpacket::connect(name),
-	);
+	let (server_socket, client_socket) = tokio::join!(listener.accept(), UnixSeqpacket::connect(name),);
 	assert!(let Ok(server_socket) = server_socket);
 	assert!(let Ok(client_socket) = client_socket);
 
@@ -67,10 +64,7 @@ async fn address_ending_with_null_byte() {
 	assert!(let Ok(local_addr) = listener.local_addr());
 	assert!(local_addr == name);
 
-	let (server_socket, client_socket) = tokio::join!(
-		listener.accept(),
-		UnixSeqpacket::connect(name),
-	);
+	let (server_socket, client_socket) = tokio::join!(listener.accept(), UnixSeqpacket::connect(name),);
 	assert!(let Ok(server_socket) = server_socket);
 	assert!(let Ok(client_socket) = client_socket);
 

--- a/tests/ancillary_fd_helper/mod.rs
+++ b/tests/ancillary_fd_helper/mod.rs
@@ -2,8 +2,8 @@ use assert2::assert;
 use std::io::{IoSlice, IoSliceMut, Seek, Write};
 use std::os::fd::AsFd;
 use tempfile::tempfile;
-use tokio_seqpacket::UnixSeqpacket;
 use tokio_seqpacket::ancillary::{AncillaryMessageReader, AncillaryMessageWriter};
+use tokio_seqpacket::UnixSeqpacket;
 
 pub async fn receive_file_descriptor(ancillary_buf: &mut [u8]) -> AncillaryMessageReader<'_> {
 	let socket_b = {

--- a/tests/ancillary_fds.rs
+++ b/tests/ancillary_fds.rs
@@ -1,6 +1,6 @@
 use assert2::assert;
 use std::io::Read;
-use tokio_seqpacket::ancillary::{OwnedAncillaryMessage, AncillaryMessage};
+use tokio_seqpacket::ancillary::{AncillaryMessage, OwnedAncillaryMessage};
 
 mod ancillary_fd_helper;
 use ancillary_fd_helper::receive_file_descriptor;
@@ -56,7 +56,9 @@ async fn pass_fd_unaligned_buffer() {
 	// Receive a file descriptor
 	let mut ancillary_buffer = [0; 64];
 	// But use a purposefully misaligned ancillary buffer.
-	let align = ancillary_buffer.as_ptr().align_offset(AncillaryMessageWriter::BUFFER_ALIGN);
+	let align = ancillary_buffer
+		.as_ptr()
+		.align_offset(AncillaryMessageWriter::BUFFER_ALIGN);
 	let ancillary = receive_file_descriptor(&mut ancillary_buffer[align + 1..]).await;
 
 	// Check that we got exactly one control message containing file descriptors.

--- a/tests/ancillary_fds_dropped.rs
+++ b/tests/ancillary_fds_dropped.rs
@@ -1,5 +1,5 @@
 use assert2::assert;
-use std::os::fd::{AsRawFd, OwnedFd, FromRawFd};
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
 use tokio_seqpacket::ancillary::AncillaryMessage;
 
 mod ancillary_fd_helper;

--- a/tests/multiple_fds.rs
+++ b/tests/multiple_fds.rs
@@ -1,9 +1,9 @@
 use assert2::assert;
-use std::io::{IoSlice, IoSliceMut, Seek, Write, Read};
+use std::io::{IoSlice, IoSliceMut, Read, Seek, Write};
 use std::os::fd::AsFd;
 use tempfile::tempfile;
-use tokio_seqpacket::UnixSeqpacket;
 use tokio_seqpacket::ancillary::{AncillaryMessageReader, AncillaryMessageWriter, OwnedAncillaryMessage};
+use tokio_seqpacket::UnixSeqpacket;
 
 pub async fn receive_file_descriptor(ancillary_buf: &mut [u8]) -> AncillaryMessageReader<'_> {
 	let socket_b = {


### PR DESCRIPTION
As I started working on an unrelated feature in my fork I've noticed that the codebase isn't formatted according to its `rustfmt.toml` configuration. This quick PR formats it and adds a CI job to ensure the code has the right formatting before merging in the future.