### PR TITLE
Feat: peek methods

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,17 +52,9 @@ jobs:
           components: clippy
           target: ${{ matrix.target }}
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          toolchain: ${{ matrix.rust }}
-          args: --all-features --color=always --target ${{ matrix.target }}
+        run: rustup run ${{ matrix.rust }} cargo build --features non-portable --color=always --target ${{ matrix.target }}
       - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          toolchain: ${{ matrix.rust }}
-          args: --all-features --color=always --target ${{ matrix.target }}
+        run: rustup run ${{ matrix.rust }} cargo test  --features non-portable --color=always --target ${{ matrix.target }}
       - name: Clippy
         uses: actions-rs/clippy-check@v1
         if: matrix.build == 'nightly'
@@ -70,6 +62,11 @@ jobs:
           toolchain: ${{ matrix.rust }}
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --release --all-features
+      - name: Documentation
+        if: matrix.build == 'nightly'
+        env:
+          RUSTDOCFLAGS: -Dwarnings
+        run: rustup run ${{ matrix.rust }} cargo doc  --all-features --color=always --target ${{ matrix.target }}
 
   vmactions:
     runs-on: ubuntu-latest
@@ -91,9 +88,9 @@ jobs:
         shell: freebsd {0}
         run: |
           . $HOME/.cargo/env
-          cargo build --all-features --color=always
+          cargo build --features non-portable --color=always
       - name: Test
         shell: freebsd {0}
         run: |
           . $HOME/.cargo/env
-          cargo test --all-features --color=always
+          cargo test --features non-portable --color=always

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ edition = "2021"
 
 [features]
 non-portable = []
+doc-cfg = []
 
 [dependencies]
 libc = "0.2.137"
@@ -26,3 +27,6 @@ filedesc = "0.6.1"
 assert2 = "0.4.0"
 tokio = { version = "1.22", features = ["rt", "rt-multi-thread", "macros", "time"] }
 tempfile = "3.3.0"
+
+[package.metadata.docs.rs]
+all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ categories = ["network-programming", "os::unix-apis"]
 
 edition = "2021"
 
+[features]
+non-portable = []
+
 [dependencies]
 libc = "0.2.137"
 tokio = { version = "1.22", features = ["net"] }

--- a/README.md
+++ b/README.md
@@ -38,15 +38,16 @@ let mut socket = UnixSeqpacket::connect("/run/foo.sock").await?;
 socket.send(b"Hello!").await?;
 
 let mut buffer = [0u8; 128];
-let len = socket.recv(&mut buffer).await?;
+let msg_info = socket.recv(&mut buffer).await?;
+let len = msg_info.bytes_read();
 println!("{}", String::from_utf8_lossy(&buffer[..len]));
 ```
 
 ## Non-portable features
 
-This crate mostly exposes APIs for portable POSIX functionality. However, it also supports some OS-specific features,
-such sending and receiving credentials as ancillary data, and peeking at the contents of ancillary data. To avoid
-accidentally writing non-portable code, these are gated behind the `non-portable` crate feature.
+This crate mostly exposes APIs for portable POSIX functionality.
+However, it also supports some OS-specific features, such sending and receiving credentials as ancillary data, and peeking at the contents of ancillary data.
+To avoid accidentally writing non-portable code, these are gated behind the `non-portable` crate feature.
 
 [`UnixSeqpacketListener`]: https://docs.rs/tokio-seqpacket/latest/tokio_seqpacket/struct.UnixSeqpacketListener.html
 [`UnixSeqpacket`]: https://docs.rs/tokio-seqpacket/latest/tokio_seqpacket/struct.UnixSeqpacket.html

--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ let len = socket.recv(&mut buffer).await?;
 println!("{}", String::from_utf8_lossy(&buffer[..len]));
 ```
 
+## Non-portable features
+
+This crate mostly exposes APIs for portable POSIX functionality. However, it also supports some OS-specific features,
+such sending and receiving credentials as ancillary data, and peeking at the contents of ancillary data. To avoid
+accidentally writing non-portable code, these are gated behind the `non-portable` crate feature.
+
 [`UnixSeqpacketListener`]: https://docs.rs/tokio-seqpacket/latest/tokio_seqpacket/struct.UnixSeqpacketListener.html
 [`UnixSeqpacket`]: https://docs.rs/tokio-seqpacket/latest/tokio_seqpacket/struct.UnixSeqpacket.html
 [`UnixSeqpacket::pair()`]: https://docs.rs/tokio-seqpacket/latest/tokio_seqpacket/struct.UnixSeqpacket.html#method.pair

--- a/src/ancillary/mod.rs
+++ b/src/ancillary/mod.rs
@@ -10,30 +10,36 @@ pub use writer::{AddControlMessageError, AncillaryMessageWriter};
 
 const FD_SIZE: usize = std::mem::size_of::<BorrowedFd>();
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
-pub(crate) type RawScmCreds = libc::ucred;
+#[cfg(feature = "non-portable")]
+mod non_portable {
+	#[cfg(any(target_os = "android", target_os = "linux"))]
+	pub(crate) type RawScmCreds = libc::ucred;
 
-#[cfg(target_os = "netbsd")]
-#[repr(C)]
-// Custom type for NetBSD socketcred.
-// Source:
-// * https://man.netbsd.org/NetBSD-8.0/unix.4
-// * https://man.netbsd.org/NetBSD-9.0/unix.4
-// * https://man.netbsd.org/NetBSD-10.0-STABLE/unix.4
-//
-// But set size of sc_groups array to 0, because we never fill it in.
-pub(crate) struct RawScmCreds {
-	pub sc_pid: libc::pid_t,
-	pub sc_uid: libc::uid_t,
-	pub sc_euid: libc::uid_t,
-	pub sc_gid: libc::gid_t,
-	pub sc_egid: libc::gid_t,
-	pub sc_ngroups: libc::c_int,
-	pub sc_groups: [libc::gid_t; 0],
+	#[cfg(target_os = "netbsd")]
+	#[repr(C)]
+	// Custom type for NetBSD socketcred.
+	// Source:
+	// * https://man.netbsd.org/NetBSD-8.0/unix.4
+	// * https://man.netbsd.org/NetBSD-9.0/unix.4
+	// * https://man.netbsd.org/NetBSD-10.0-STABLE/unix.4
+	//
+	// But set size of sc_groups array to 0, because we never fill it in.
+	pub(crate) struct RawScmCreds {
+		pub sc_pid: libc::pid_t,
+		pub sc_uid: libc::uid_t,
+		pub sc_euid: libc::uid_t,
+		pub sc_gid: libc::gid_t,
+		pub sc_egid: libc::gid_t,
+		pub sc_ngroups: libc::c_int,
+		pub sc_groups: [libc::gid_t; 0],
+	}
+
+	#[cfg(any(target_os = "android", target_os = "linux"))]
+	pub(super) const SCM_CREDENTIALS: libc::c_int = libc::SCM_CREDENTIALS;
+
+	#[cfg(target_os = "netbsd")]
+	pub(super) const SCM_CREDENTIALS: libc::c_int = libc::SCM_CREDS;
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
-const SCM_CREDENTIALS: libc::c_int = libc::SCM_CREDENTIALS;
-
-#[cfg(target_os = "netbsd")]
-const SCM_CREDENTIALS: libc::c_int = libc::SCM_CREDS;
+#[cfg(feature = "non-portable")]
+pub(crate) use non_portable::*;

--- a/src/ancillary/mod.rs
+++ b/src/ancillary/mod.rs
@@ -42,4 +42,5 @@ mod non_portable {
 }
 
 #[cfg(feature = "non-portable")]
+#[allow(unused_imports, reason = "may or may not import something, depending on platform")]
 pub(crate) use non_portable::*;

--- a/src/ancillary/reader.rs
+++ b/src/ancillary/reader.rs
@@ -57,7 +57,10 @@ pub enum AncillaryMessage<'a> {
 	FileDescriptors(FileDescriptors<'a>),
 
 	/// Ancillary message holding unix credentials.
-	#[cfg(any(doc, target_os = "android", target_os = "linux", target_os = "netbsd",))]
+	#[cfg(all(
+		feature = "non-portable",
+		any(target_os = "android", target_os = "linux", target_os = "netbsd")
+	))]
 	Credentials(UnixCredentials<'a>),
 
 	/// Ancillary message uninterpreted data.
@@ -72,7 +75,10 @@ pub enum OwnedAncillaryMessage<'a> {
 	FileDescriptors(OwnedFileDescriptors<'a>),
 
 	/// Ancillary message holding unix credentials.
-	#[cfg(any(doc, target_os = "android", target_os = "linux", target_os = "netbsd",))]
+	#[cfg(all(
+		feature = "non-portable",
+		any(target_os = "android", target_os = "linux", target_os = "netbsd")
+	))]
 	Credentials(UnixCredentials<'a>),
 
 	/// Ancillary message uninterpreted data.
@@ -94,7 +100,10 @@ pub struct OwnedFileDescriptors<'a> {
 
 /// A control message containing unix credentials for a process.
 #[derive(Copy, Clone)]
-#[cfg(any(doc, target_os = "linux", target_os = "android", target_os = "netbsd"))]
+#[cfg(all(
+	feature = "non-portable",
+	any(target_os = "android", target_os = "linux", target_os = "netbsd")
+))]
 pub struct UnixCredentials<'a> {
 	/// The message data.
 	data: &'a [u8],
@@ -236,7 +245,10 @@ impl<'a> AncillaryMessage<'a> {
 
 			match (cmsg.cmsg_level, cmsg.cmsg_type) {
 				(libc::SOL_SOCKET, libc::SCM_RIGHTS) => Self::FileDescriptors(FileDescriptors { data }),
-				#[cfg(any(target_os = "android", target_os = "linux", target_os = "netbsd"))]
+				#[cfg(all(
+					feature = "non-portable",
+					any(target_os = "android", target_os = "linux", target_os = "netbsd")
+				))]
 				(libc::SOL_SOCKET, super::SCM_CREDENTIALS) => Self::Credentials(UnixCredentials { data }),
 				(cmsg_level, cmsg_type) => Self::Other(UnknownMessage {
 					cmsg_level,
@@ -303,7 +315,10 @@ impl<'a> OwnedAncillaryMessage<'a> {
 
 			match (cmsg.cmsg_level, cmsg.cmsg_type) {
 				(libc::SOL_SOCKET, libc::SCM_RIGHTS) => Self::FileDescriptors(OwnedFileDescriptors { data }),
-				#[cfg(any(target_os = "android", target_os = "linux", target_os = "netbsd"))]
+				#[cfg(all(
+					feature = "non-portable",
+					any(target_os = "android", target_os = "linux", target_os = "netbsd")
+				))]
 				(libc::SOL_SOCKET, super::SCM_CREDENTIALS) => Self::Credentials(UnixCredentials { data }),
 				(cmsg_level, cmsg_type) => Self::Other(UnknownMessage {
 					cmsg_level,
@@ -416,7 +431,10 @@ impl<'a> std::iter::ExactSizeIterator for OwnedFileDescriptors<'a> {
 	}
 }
 
-#[cfg(any(target_os = "linux", target_os = "android", target_os = "netbsd"))]
+#[cfg(all(
+	feature = "non-portable",
+	any(target_os = "linux", target_os = "android", target_os = "netbsd")
+))]
 mod unix_creds_impl {
 	use super::super::RawScmCreds;
 	use super::UnixCredentials;

--- a/src/ancillary/writer.rs
+++ b/src/ancillary/writer.rs
@@ -141,7 +141,10 @@ impl<'a> AncillaryMessageWriter<'a> {
 	///
 	/// This function adds a single control message with level `SOL_SOCKET` and type `SCM_CREDENTIALS` on most platforms.
 	/// On NetBSD the message has type `SCM_CREDS`.
-	#[cfg(any(target_os = "android", target_os = "linux", target_os = "netbsd"))]
+	#[cfg(all(
+		feature = "non-portable",
+		any(target_os = "android", target_os = "linux", target_os = "netbsd")
+	))]
 	pub fn add_ucreds<'c, I>(&mut self, credentials: I) -> Result<(), AddControlMessageError>
 	where
 		I: IntoIterator<Item = &'c crate::UCred, IntoIter: ExactSizeIterator>,
@@ -180,18 +183,6 @@ impl<'a> AncillaryMessageWriter<'a> {
 		// SAFETY: the cmsg data is valid and fully initialized.
 		unsafe { cmsg.commit() };
 		Ok(())
-	}
-
-	/// Add Unix credentials to the ancillary data.
-	///
-	/// The function returns `Ok(())` if there is enough space in the buffer.
-	/// If there is not enough space, then no credentials are appended.
-	///
-	/// This function adds a single control message with level `SOL_SOCKET` and type `SCM_CREDENTIALS` on most platforms.
-	/// On NetBSD the message has type `SCM_CREDS`.
-	#[cfg(all(doc, not(any(target_os = "android", target_os = "linux", target_os = "netbsd"))))]
-	pub fn add_ucreds(&mut self, credentials: &[crate::UCred]) -> Result<(), AddControlMessageError> {
-		panic!("fake function for doc generation")
 	}
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,8 @@
 //! socket.send(b"Hello!").await?;
 //!
 //! let mut buffer = [0u8; 128];
-//! let len = socket.recv(&mut buffer).await?;
+//! let msg_info = socket.recv(&mut buffer).await?;
+//! let len = msg_info.bytes_read();
 //! println!("{}", String::from_utf8_lossy(&buffer[..len]));
 //! # Ok(())
 //! # }
@@ -59,7 +60,7 @@ mod sys;
 mod ucred;
 
 pub use listener::UnixSeqpacketListener;
-pub use socket::UnixSeqpacket;
+pub use socket::{MessageInfo, UnixSeqpacket};
 pub use ucred::UCred;
 
 #[doc(hidden)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,12 @@
 //! # Ok(())
 //! # }
 //! ```
+//!
+//! # Non-portable features
+//!
+//! This crate mostly exposes APIs for portable POSIX functionality.
+//! However, it also supports some OS-specific features, such sending and receiving credentials as ancillary data, and peeking at the contents of ancillary data.
+//! To avoid accidentally writing non-portable code, these are gated behind the `non-portable` crate feature.
 
 #![warn(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@
 //! ```
 
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 macro_rules! ready {
 	($e:expr) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@
 //! To avoid accidentally writing non-portable code, these are gated behind the `non-portable` crate feature.
 
 #![warn(missing_docs)]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(feature = "doc-cfg", feature(doc_cfg))]
 
 macro_rules! ready {
 	($e:expr) => {

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -436,7 +436,7 @@ impl UnixSeqpacket {
 	///
 	/// Note that unlike [`Self::peek_with_ancillary`], only the last task calling this function will be woken up.
 	/// For that reason, it is preferable to use the async functions rather than polling functions when possible.
-	#[cfg(any(target_os = "linux", target_os = "android"))]
+	#[cfg(all(feature = "non-portable", any(target_os = "linux", target_os = "android")))]
 	pub fn poll_peek_with_ancillary<'a>(
 		&self,
 		cx: &mut Context,
@@ -462,7 +462,7 @@ impl UnixSeqpacket {
 	///
 	/// Note that unlike [`Self::peek_vectored_with_ancillary`], only the last task calling this function will be woken up.
 	/// For that reason, it is preferable to use the async functions rather than polling functions when possible.
-	#[cfg(any(target_os = "linux", target_os = "android"))]
+	#[cfg(all(feature = "non-portable", any(target_os = "linux", target_os = "android")))]
 	pub fn poll_peek_vectored_with_ancillary<'a>(
 		&self,
 		cx: &mut Context,
@@ -600,7 +600,7 @@ impl UnixSeqpacket {
 	/// This function is safe to call concurrently from different tasks.
 	/// All calling tasks will try to complete the asynchronous action,
 	/// although the order in which they complete is not guaranteed.
-	#[cfg(any(target_os = "linux", target_os = "android"))]
+	#[cfg(all(feature = "non-portable", any(target_os = "linux", target_os = "android")))]
 	pub async fn peek_with_ancillary<'a>(
 		&self,
 		buffer: &mut [u8],
@@ -625,7 +625,7 @@ impl UnixSeqpacket {
 	/// This function is safe to call concurrently from different tasks.
 	/// All calling tasks will try to complete the asynchronous action,
 	/// although the order in which they complete is not guaranteed.
-	#[cfg(any(target_os = "linux", target_os = "android"))]
+	#[cfg(all(feature = "non-portable", any(target_os = "linux", target_os = "android")))]
 	pub async fn peek_vectored_with_ancillary<'a>(
 		&self,
 		buffer: &mut [IoSliceMut<'_>],

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -8,11 +8,73 @@ use tokio::io::unix::AsyncFd;
 use crate::ancillary::{AncillaryMessageReader, AncillaryMessageWriter};
 use crate::{sys, UCred};
 
+/// Information about a received seqpacket message.
+#[derive(Debug, Clone)]
+pub struct MessageInfo {
+	pub(crate) bytes_read: usize,
+	pub(crate) truncated: bool,
+	pub(crate) ancillary_truncated: bool,
+}
+
+impl MessageInfo {
+	/// Get the number of data bytes that were read.
+	///
+	/// A value of zero either indicates an empty seqpacket message or that the sender closed
+	/// their half of the connection and all messages have been received.
+	pub fn bytes_read(&self) -> usize {
+		self.bytes_read
+	}
+
+	/// Whether the message was truncated due to insufficient buffer space.
+	///
+	/// The truncated bytes of a received message are lost forever. As such, you should ensure
+	/// that your buffer is large enough for the expected messages, or [peek] at the message
+	/// first to dynamically resize the receive buffer if necessary.
+	///
+	/// [peek]: UnixSeqpacket::peek
+	pub fn truncated(&self) -> bool {
+		self.truncated
+	}
+
+	/// Whether the message's ancillary data was truncated due to insufficient buffer space.
+	///
+	/// The truncated ancillary data of a received message is lost forever. As such, you should
+	/// ensure that your ancillary buffer is large enough for the expected messages, or, if
+	/// writing code for platforms that support this (like Linux and Android), [peek] at
+	/// the message first to dynamically resize the ancillary buffer if necessary.
+	///
+	/// [peek]: UnixSeqpacket::peek_vectored_with_ancillary
+	pub fn ancillary_truncated(&self) -> bool {
+		self.ancillary_truncated
+	}
+}
+
 /// Unix seqpacket socket.
 ///
 /// Note that there are no functions to get the local or remote address of the connection.
 /// That is because connected Unix sockets are always anonymous,
 /// which means that the address contains no useful information.
+///
+/// ## `peek` Methods and Ancillary Data
+///
+/// This type exposes methods to peek at the next message to be received. However, the POSIX
+/// standard does not specify how peeking at a seqpacket/datagram affects its ancillary data.
+///
+/// On Linux and Android, ancillary file descriptors are cloned when peeking, so they are
+/// not lost to subsequent `peek` or `recv` calls. This makes it possible to expose
+/// [`poll_peek_vectored_with_ancillary`] and [`peek_vectored_with_ancillary`] methods that
+/// have the same ancillary ownership semantics as their `recv` variants. These methods
+/// are gated behind the `non-portable` feature.
+///
+/// Other operating systems may behave differently, such as:
+/// - Returning file descriptors from the next message without cloning them (FreeBSD);
+/// - Consuming ancillary data, even when a empty ancillary buffer is passed;
+/// - Returning no ancillary data, even when the message has some.
+///
+/// If writing portable code, consider peeking only when ancillary data is not expected.
+///
+/// [`poll_peek_vectored_with_ancillary`]: Self::poll_peek_vectored_with_ancillary
+/// [`peek_vectored_with_ancillary`]: Self::peek_vectored_with_ancillary
 pub struct UnixSeqpacket {
 	io: AsyncFd<FileDesc>,
 }
@@ -235,14 +297,21 @@ impl UnixSeqpacket {
 	///
 	/// Note that unlike [`Self::recv`], only the last task calling this function will be woken up.
 	/// For that reason, it is preferable to use the async functions rather than polling functions when possible.
-	pub fn poll_recv(&self, cx: &mut Context, buffer: &mut [u8]) -> Poll<std::io::Result<usize>> {
-		loop {
-			let mut ready_guard = ready!(self.io.poll_read_ready(cx)?);
-			match ready_guard.try_io(|inner| sys::recv(inner.get_ref(), buffer)) {
-				Ok(result) => return Poll::Ready(result),
-				Err(_would_block) => continue,
-			}
-		}
+	pub fn poll_recv(&self, cx: &mut Context, buffer: &mut [u8]) -> Poll<std::io::Result<MessageInfo>> {
+		self.poll_recv_vectored(cx, &mut [IoSliceMut::new(buffer)])
+	}
+
+	/// Try to peek at the next message on the socket from the connected peer without blocking.
+	///
+	/// Peeking a message with ancillary data may consume or omit it on some platforms. See the
+	/// [type level documentation](UnixSeqpacket) for more information.
+	///
+	/// If there is no data ready yet, the current task is scheduled to wake up when the socket becomes readable.
+	///
+	/// Note that unlike [`Self::poll`], only the last task calling this function will be woken up.
+	/// For that reason, it is preferable to use the async functions rather than polling functions when possible.
+	pub fn poll_peek(&self, cx: &mut Context, buffer: &mut [u8]) -> Poll<std::io::Result<MessageInfo>> {
+		self.poll_peek_vectored(cx, &mut [IoSliceMut::new(buffer)])
 	}
 
 	/// Try to receive data on the socket from the connected peer without blocking.
@@ -251,8 +320,30 @@ impl UnixSeqpacket {
 	///
 	/// Note that unlike [`Self::recv_vectored`], only the last task calling this function will be woken up.
 	/// For that reason, it is preferable to use the async functions rather than polling functions when possible.
-	pub fn poll_recv_vectored(&self, cx: &mut Context, buffer: &mut [IoSliceMut]) -> Poll<std::io::Result<usize>> {
+	pub fn poll_recv_vectored(
+		&self,
+		cx: &mut Context,
+		buffer: &mut [IoSliceMut],
+	) -> Poll<std::io::Result<MessageInfo>> {
 		let (read, _ancillary) = ready!(self.poll_recv_vectored_with_ancillary(cx, buffer, &mut []))?;
+		Poll::Ready(Ok(read))
+	}
+
+	/// Try to peek at the next message on the socket from the connected peer without blocking.
+	///
+	/// Peeking a message with ancillary data may consume or omit it on some platforms. See the
+	/// [type level documentation](UnixSeqpacket) for more information.
+	///
+	/// If there is no data ready yet, the current task is scheduled to wake up when the socket becomes readable.
+	///
+	/// Note that unlike [`Self::recv_vectored`], only the last task calling this function will be woken up.
+	/// For that reason, it is preferable to use the async functions rather than polling functions when possible.
+	pub fn poll_peek_vectored(
+		&self,
+		cx: &mut Context,
+		buffer: &mut [IoSliceMut],
+	) -> Poll<std::io::Result<MessageInfo>> {
+		let (read, _ancillary) = ready!(self.poll_recv_vectored_with_ancillary_internal(cx, buffer, &mut [], true))?;
 		Poll::Ready(Ok(read))
 	}
 
@@ -274,12 +365,49 @@ impl UnixSeqpacket {
 		cx: &mut Context,
 		buffer: &mut [IoSliceMut],
 		ancillary_buffer: &'a mut [u8],
-	) -> Poll<std::io::Result<(usize, AncillaryMessageReader<'a>)>> {
+	) -> Poll<std::io::Result<(MessageInfo, AncillaryMessageReader<'a>)>> {
+		self.poll_recv_vectored_with_ancillary_internal(cx, buffer, ancillary_buffer, false)
+	}
+
+	/// Try to peek at the next message and its ancillary data on the socket from the connected peer without blocking.
+	///
+	/// Any file descriptors received in the anicallary data will have the `close-on-exec` flag set.
+	/// If the OS supports it, this is done atomically with the reception of the message.
+	/// However, on Illumos and Solaris, the `close-on-exec` flag is set in a separate step after receiving the message.
+	///
+	/// Note that you should always wrap or close any file descriptors received this way.
+	/// If you do not, the received file descriptors will stay open until the process is terminated.
+	///
+	/// Peeking a message with ancillary data may consume or omit it on some platforms. See the
+	/// [type level documentation](UnixSeqpacket) for more information.
+	///
+	/// If there is no data ready yet, the current task is scheduled to wake up when the socket becomes readable.
+	///
+	/// Note that unlike [`Self::peek_vectored_with_ancillary`], only the last task calling this function will be woken up.
+	/// For that reason, it is preferable to use the async functions rather than polling functions when possible.
+	#[cfg(any(target_os = "linux", target_os = "android"))]
+	pub fn poll_peek_vectored_with_ancillary<'a>(
+		&self,
+		cx: &mut Context,
+		buffer: &mut [IoSliceMut],
+		ancillary_buffer: &'a mut [u8],
+	) -> Poll<std::io::Result<(MessageInfo, AncillaryMessageReader<'a>)>> {
+		self.poll_recv_vectored_with_ancillary_internal(cx, buffer, ancillary_buffer, true)
+	}
+
+	/// Shared implementation of `poll_recv_vectored_with_ancillary` and `poll_peek_vectored_with_ancillary`.
+	fn poll_recv_vectored_with_ancillary_internal<'a>(
+		&self,
+		cx: &mut Context,
+		buffer: &mut [IoSliceMut],
+		ancillary_buffer: &'a mut [u8],
+		peek: bool,
+	) -> Poll<std::io::Result<(MessageInfo, AncillaryMessageReader<'a>)>> {
 		loop {
 			let mut ready_guard = ready!(self.io.poll_read_ready(cx)?);
 
 			let (read, ancillary_reader) =
-				match ready_guard.try_io(|inner| sys::recv_msg(inner.get_ref(), buffer, ancillary_buffer)) {
+				match ready_guard.try_io(|inner| sys::recv_msg(inner.get_ref(), buffer, ancillary_buffer, peek)) {
 					Ok(x) => x?,
 					Err(_would_block) => continue,
 				};
@@ -297,14 +425,20 @@ impl UnixSeqpacket {
 	/// This function is safe to call concurrently from different tasks.
 	/// All calling tasks will try to complete the asynchronous action,
 	/// although the order in which they complete is not guaranteed.
-	pub async fn recv(&self, buffer: &mut [u8]) -> std::io::Result<usize> {
-		loop {
-			let mut ready_guard = self.io.readable().await?;
-			match ready_guard.try_io(|inner| sys::recv(inner.get_ref(), buffer)) {
-				Ok(result) => return result,
-				Err(_would_block) => continue,
-			}
-		}
+	pub async fn recv(&self, buffer: &mut [u8]) -> std::io::Result<MessageInfo> {
+		self.recv_vectored(&mut [IoSliceMut::new(buffer)]).await
+	}
+
+	/// Peek at the next message on the socket from the connected peer.
+	///
+	/// Peeking a message with ancillary data may consume or omit it on some platforms. See the
+	/// [type level documentation](UnixSeqpacket) for more information.
+	///
+	/// This function is safe to call concurrently from different tasks.
+	/// All calling tasks will try to complete the asynchronous action,
+	/// although the order in which they complete is not guaranteed.
+	pub async fn peek(&self, buffer: &mut [u8]) -> std::io::Result<MessageInfo> {
+		self.peek_vectored(&mut [IoSliceMut::new(buffer)]).await
 	}
 
 	/// Receive data on the socket from the connected peer.
@@ -312,8 +446,23 @@ impl UnixSeqpacket {
 	/// This function is safe to call concurrently from different tasks.
 	/// All calling tasks will try to complete the asynchronous action,
 	/// although the order in which they complete is not guaranteed.
-	pub async fn recv_vectored(&self, buffer: &mut [IoSliceMut<'_>]) -> std::io::Result<usize> {
+	pub async fn recv_vectored(&self, buffer: &mut [IoSliceMut<'_>]) -> std::io::Result<MessageInfo> {
 		let (read, _ancillary) = self.recv_vectored_with_ancillary(buffer, &mut []).await?;
+		Ok(read)
+	}
+
+	/// Peek at the next message on the socket from the connected peer.
+	///
+	/// Peeking a message with ancillary data may consume or omit it on some platforms. See the
+	/// [type level documentation](UnixSeqpacket) for more information.
+	///
+	/// This function is safe to call concurrently from different tasks.
+	/// All calling tasks will try to complete the asynchronous action,
+	/// although the order in which they complete is not guaranteed.
+	pub async fn peek_vectored(&self, buffer: &mut [IoSliceMut<'_>]) -> std::io::Result<MessageInfo> {
+		let (read, _ancillary) = self
+			.recv_vectored_with_ancillary_internal(buffer, &mut [], true)
+			.await?;
 		Ok(read)
 	}
 
@@ -333,12 +482,48 @@ impl UnixSeqpacket {
 		&self,
 		buffer: &mut [IoSliceMut<'_>],
 		ancillary_buffer: &'a mut [u8],
-	) -> std::io::Result<(usize, AncillaryMessageReader<'a>)> {
+	) -> std::io::Result<(MessageInfo, AncillaryMessageReader<'a>)> {
+		self.recv_vectored_with_ancillary_internal(buffer, ancillary_buffer, false)
+			.await
+	}
+
+	/// Peek at the next message and its ancillary data on the socket from the connected peer.
+	///
+	/// Any file descriptors received in the anicallary data will have the `close-on-exec` flag set.
+	/// If the OS supports it, this is done atomically with the reception of the message.
+	/// However, on Illumos and Solaris, the `close-on-exec` flag is set in a separate step after receiving the message.
+	///
+	/// Note that you should always wrap or close any file descriptors received this way.
+	/// If you do not, the received file descriptors will stay open until the process is terminated.
+	///
+	/// Peeking a message with ancillary data may consume or omit it on some platforms. See the
+	/// [type level documentation](UnixSeqpacket) for more information.
+	///
+	/// This function is safe to call concurrently from different tasks.
+	/// All calling tasks will try to complete the asynchronous action,
+	/// although the order in which they complete is not guaranteed.
+	#[cfg(any(target_os = "linux", target_os = "android"))]
+	pub async fn peek_vectored_with_ancillary<'a>(
+		&self,
+		buffer: &mut [IoSliceMut<'_>],
+		ancillary_buffer: &'a mut [u8],
+	) -> std::io::Result<(MessageInfo, AncillaryMessageReader<'a>)> {
+		self.recv_vectored_with_ancillary_internal(buffer, ancillary_buffer, true)
+			.await
+	}
+
+	/// Shared implementation of `read_vectored_with_ancillary` and `poll_vectored_with_ancillary`.
+	async fn recv_vectored_with_ancillary_internal<'a>(
+		&self,
+		buffer: &mut [IoSliceMut<'_>],
+		ancillary_buffer: &'a mut [u8],
+		peek: bool,
+	) -> std::io::Result<(MessageInfo, AncillaryMessageReader<'a>)> {
 		loop {
 			let mut ready_guard = self.io.readable().await?;
 
 			let (read, ancillary_reader) =
-				match ready_guard.try_io(|inner| sys::recv_msg(inner.get_ref(), buffer, ancillary_buffer)) {
+				match ready_guard.try_io(|inner| sys::recv_msg(inner.get_ref(), buffer, ancillary_buffer, peek)) {
 					Ok(x) => x?,
 					Err(_would_block) => continue,
 				};

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -25,25 +25,26 @@ impl MessageInfo {
 		self.bytes_read
 	}
 
-	/// Whether the message was truncated due to insufficient buffer space.
+	/// Check if the message was truncated due to insufficient buffer space.
 	///
-	/// The truncated bytes of a received message are lost forever. As such, you should ensure
-	/// that your buffer is large enough for the expected messages, or [peek] at the message
-	/// first to dynamically resize the receive buffer if necessary.
+	/// The truncated bytes of a received message are lost forever.
+	/// As such, you should ensure that your buffer is large enough for the expected messages,
+	/// or [peek] at the message first to dynamically resize the receive buffer if necessary.
+	/// But keep in mind that peeking at a message may consume the ancillary data, making it impossible to retrieve later.
 	///
 	/// [peek]: UnixSeqpacket::peek
 	pub fn truncated(&self) -> bool {
 		self.truncated
 	}
 
-	/// Whether the message's ancillary data was truncated due to insufficient buffer space.
+	/// Check if the ancillary data was truncated due to insufficient buffer space.
 	///
-	/// The truncated ancillary data of a received message is lost forever. As such, you should
-	/// ensure that your ancillary buffer is large enough for the expected messages, or, if
-	/// writing code for platforms that support this (like Linux and Android), [peek] at
-	/// the message first to dynamically resize the ancillary buffer if necessary.
+	/// The truncated ancillary data of a received message is lost forever.
+	/// As such, you should ensure that your ancillary buffer is large enough for the expected messages.
+	/// Alternatively, if your platform supports it (like Linux and Android),
+	/// you can [peek] at the message first to dynamically resize the ancillary buffer as necessary.
 	///
-	/// [peek]: UnixSeqpacket::peek_vectored_with_ancillary
+	/// [peek]: UnixSeqpacket::peek_with_ancillary
 	pub fn ancillary_truncated(&self) -> bool {
 		self.ancillary_truncated
 	}
@@ -57,14 +58,14 @@ impl MessageInfo {
 ///
 /// ## `peek` Methods and Ancillary Data
 ///
-/// This type exposes methods to peek at the next message to be received. However, the POSIX
-/// standard does not specify how peeking at a seqpacket/datagram affects its ancillary data.
+/// This type exposes methods to peek at the next message to be received.
+/// However, the POSIX standard does not specify how peeking at a seqpacket/datagram affects its ancillary data.
 ///
-/// On Linux and Android, ancillary file descriptors are cloned when peeking, so they are
-/// not lost to subsequent `peek` or `recv` calls. This makes it possible to expose
-/// [`poll_peek_vectored_with_ancillary`] and [`peek_vectored_with_ancillary`] methods that
-/// have the same ancillary ownership semantics as their `recv` variants. These methods
-/// are gated behind the `non-portable` feature.
+/// On Linux and Android, ancillary file descriptors are cloned when peeking,
+/// so they are not lost to subsequent `peek` or `recv` calls.
+/// This makes it possible to expose [`poll_peek_vectored_with_ancillary`] and [`peek_vectored_with_ancillary`] methods
+/// that have the same ancillary ownership semantics as their `recv` variants.
+/// These methods are gated behind the `non-portable` feature.
 ///
 /// Other operating systems may behave differently, such as:
 /// - Returning file descriptors from the next message without cloning them (FreeBSD);
@@ -170,9 +171,8 @@ impl UnixSeqpacket {
 
 	/// Get the async file descriptor of this object.
 	///
-	/// This can be useful for applications that want to do low-level socket calls, such as
-	/// [`sendmsg`](libc::sendmsg), but still want to use async and need to know when the socket is
-	/// ready to be used.
+	/// This can be useful for applications that want to do low-level socket calls, such as [`sendmsg`](libc::sendmsg),
+	/// but still want to use async and need to know when the socket is ready to be used.
 	///
 	/// Example:
 	/// ```
@@ -187,8 +187,7 @@ impl UnixSeqpacket {
 
 	/// Get the effective credentials of the process which called `connect` or `pair`.
 	///
-	/// Note that this is not necessarily the process that currently has the file descriptor
-	/// of the other side of the connection.
+	/// Note that this is not necessarily the process that currently has the file descriptor of the other side of the connection.
 	pub fn peer_cred(&self) -> std::io::Result<UCred> {
 		UCred::from_socket_peer(&self.io)
 	}
@@ -332,8 +331,8 @@ impl UnixSeqpacket {
 
 	/// Try to peek at the next message on the socket from the connected peer without blocking.
 	///
-	/// Peeking a message with ancillary data may consume or omit it on some platforms. See the
-	/// [type level documentation](UnixSeqpacket) for more information.
+	/// Peeking a message with ancillary data may consume or omit it on some platforms.
+	/// See the [`UnixSeqpacket`] documentation for more information.
 	///
 	/// If there is no data ready yet, the current task is scheduled to wake up when the socket becomes readable.
 	///
@@ -360,8 +359,8 @@ impl UnixSeqpacket {
 
 	/// Try to peek at the next message on the socket from the connected peer without blocking.
 	///
-	/// Peeking a message with ancillary data may consume or omit it on some platforms. See the
-	/// [type level documentation](UnixSeqpacket) for more information.
+	/// Peeking a message with ancillary data may consume or omit it on some platforms.
+	/// See the [`UnixSeqpacket`] documentation for more information.
 	///
 	/// If there is no data ready yet, the current task is scheduled to wake up when the socket becomes readable.
 	///
@@ -429,8 +428,9 @@ impl UnixSeqpacket {
 	/// Note that you should always wrap or close any file descriptors received this way.
 	/// If you do not, the received file descriptors will stay open until the process is terminated.
 	///
-	/// Peeking a message with ancillary data may consume or omit it on some platforms. See the
-	/// [type level documentation](UnixSeqpacket) for more information.
+	/// Any objects in the ancillary data are duplicated.
+	/// They will be received again in subsequent calls to any peek or recv function.
+	/// Do note that the objects are *duplicated*, so file descriptors refer to the same kernel object, but they may have a different number.
 	///
 	/// If there is no data ready yet, the current task is scheduled to wake up when the socket becomes readable.
 	///
@@ -455,8 +455,9 @@ impl UnixSeqpacket {
 	/// Note that you should always wrap or close any file descriptors received this way.
 	/// If you do not, the received file descriptors will stay open until the process is terminated.
 	///
-	/// Peeking a message with ancillary data may consume or omit it on some platforms. See the
-	/// [type level documentation](UnixSeqpacket) for more information.
+	/// Any objects in the ancillary data are duplicated.
+	/// They will be received again in subsequent calls to any peek or recv function.
+	/// Do note that the objects are *duplicated*, so file descriptors refer to the same kernel object, but they may have a different number.
 	///
 	/// If there is no data ready yet, the current task is scheduled to wake up when the socket becomes readable.
 	///
@@ -508,8 +509,8 @@ impl UnixSeqpacket {
 
 	/// Peek at the next message on the socket from the connected peer.
 	///
-	/// Peeking a message with ancillary data may consume or omit it on some platforms. See the
-	/// [type level documentation](UnixSeqpacket) for more information.
+	/// Peeking a message with ancillary data may consume or omit it on some platforms.
+	/// See the [`UnixSeqpacket`] documentation for more information.
 	///
 	/// This function is safe to call concurrently from different tasks.
 	/// All calling tasks will try to complete the asynchronous action,
@@ -530,8 +531,8 @@ impl UnixSeqpacket {
 
 	/// Peek at the next message on the socket from the connected peer.
 	///
-	/// Peeking a message with ancillary data may consume or omit it on some platforms. See the
-	/// [type level documentation](UnixSeqpacket) for more information.
+	/// Peeking a message with ancillary data may consume or omit it on some platforms.
+	/// See the [`UnixSeqpacket`] documentation for more information.
 	///
 	/// This function is safe to call concurrently from different tasks.
 	/// All calling tasks will try to complete the asynchronous action,
@@ -594,8 +595,9 @@ impl UnixSeqpacket {
 	/// Note that you should always wrap or close any file descriptors received this way.
 	/// If you do not, the received file descriptors will stay open until the process is terminated.
 	///
-	/// Peeking a message with ancillary data may consume or omit it on some platforms. See the
-	/// [type level documentation](UnixSeqpacket) for more information.
+	/// Any objects in the ancillary data are duplicated.
+	/// They will be received again in subsequent calls to any peek or recv function.
+	/// Do note that the objects are *duplicated*, so file descriptors refer to the same kernel object, but they may have a different number.
 	///
 	/// This function is safe to call concurrently from different tasks.
 	/// All calling tasks will try to complete the asynchronous action,
@@ -619,8 +621,9 @@ impl UnixSeqpacket {
 	/// Note that you should always wrap or close any file descriptors received this way.
 	/// If you do not, the received file descriptors will stay open until the process is terminated.
 	///
-	/// Peeking a message with ancillary data may consume or omit it on some platforms. See the
-	/// [type level documentation](UnixSeqpacket) for more information.
+	/// Any objects in the ancillary data are duplicated.
+	/// They will be received again in subsequent calls to any peek or recv function.
+	/// Do note that the objects are *duplicated*, so file descriptors refer to the same kernel object, but they may have a different number.
 	///
 	/// This function is safe to call concurrently from different tasks.
 	/// All calling tasks will try to complete the asynchronous action,

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -229,6 +229,21 @@ impl UnixSeqpacket {
 	///
 	/// If the socket is not ready yet, the current task is scheduled to wake up when the socket becomes writeable.
 	///
+	/// Note that unlike [`Self::send_with_ancillary`], only the last task calling this function will be woken up.
+	/// For that reason, it is preferable to use the async functions rather than polling functions when possible.
+	pub fn poll_send_with_ancillary(
+		&self,
+		cx: &mut Context,
+		buffer: &[u8],
+		ancillary: &mut AncillaryMessageWriter,
+	) -> Poll<std::io::Result<usize>> {
+		self.poll_send_vectored_with_ancillary(cx, &[IoSlice::new(buffer)], ancillary)
+	}
+
+	/// Try to send data with ancillary data on the socket to the connected peer without blocking.
+	///
+	/// If the socket is not ready yet, the current task is scheduled to wake up when the socket becomes writeable.
+	///
 	/// Note that unlike [`Self::send_vectored_with_ancillary`], only the last task calling this function will be woken up.
 	/// For that reason, it is preferable to use the async functions rather than polling functions when possible.
 	pub fn poll_send_vectored_with_ancillary(
@@ -277,6 +292,20 @@ impl UnixSeqpacket {
 	/// This function is safe to call concurrently from different tasks.
 	/// All calling tasks will try to complete the asynchronous action,
 	/// although the order in which they complete is not guaranteed.
+	pub async fn send_with_ancillary(
+		&self,
+		buffer: &[u8],
+		ancillary: &mut AncillaryMessageWriter<'_>,
+	) -> std::io::Result<usize> {
+		self.send_vectored_with_ancillary(&[IoSlice::new(buffer)], ancillary)
+			.await
+	}
+
+	/// Send data with ancillary data on the socket to the connected peer.
+	///
+	/// This function is safe to call concurrently from different tasks.
+	/// All calling tasks will try to complete the asynchronous action,
+	/// although the order in which they complete is not guaranteed.
 	pub async fn send_vectored_with_ancillary(
 		&self,
 		buffer: &[IoSlice<'_>],
@@ -308,7 +337,7 @@ impl UnixSeqpacket {
 	///
 	/// If there is no data ready yet, the current task is scheduled to wake up when the socket becomes readable.
 	///
-	/// Note that unlike [`Self::poll`], only the last task calling this function will be woken up.
+	/// Note that unlike [`Self::peek`], only the last task calling this function will be woken up.
 	/// For that reason, it is preferable to use the async functions rather than polling functions when possible.
 	pub fn poll_peek(&self, cx: &mut Context, buffer: &mut [u8]) -> Poll<std::io::Result<MessageInfo>> {
 		self.poll_peek_vectored(cx, &mut [IoSliceMut::new(buffer)])
@@ -336,7 +365,7 @@ impl UnixSeqpacket {
 	///
 	/// If there is no data ready yet, the current task is scheduled to wake up when the socket becomes readable.
 	///
-	/// Note that unlike [`Self::recv_vectored`], only the last task calling this function will be woken up.
+	/// Note that unlike [`Self::peek_vectored`], only the last task calling this function will be woken up.
 	/// For that reason, it is preferable to use the async functions rather than polling functions when possible.
 	pub fn poll_peek_vectored(
 		&self,
@@ -345,6 +374,28 @@ impl UnixSeqpacket {
 	) -> Poll<std::io::Result<MessageInfo>> {
 		let (read, _ancillary) = ready!(self.poll_recv_vectored_with_ancillary_internal(cx, buffer, &mut [], true))?;
 		Poll::Ready(Ok(read))
+	}
+
+	/// Try to receive data with ancillary data on the socket from the connected peer without blocking.
+	///
+	/// Any file descriptors received in the anicallary data will have the `close-on-exec` flag set.
+	/// If the OS supports it, this is done atomically with the reception of the message.
+	/// However, on Illumos and Solaris, the `close-on-exec` flag is set in a separate step after receiving the message.
+	///
+	/// Note that you should always wrap or close any file descriptors received this way.
+	/// If you do not, the received file descriptors will stay open until the process is terminated.
+	///
+	/// If there is no data ready yet, the current task is scheduled to wake up when the socket becomes readable.
+	///
+	/// Note that unlike [`Self::recv_with_ancillary`], only the last task calling this function will be woken up.
+	/// For that reason, it is preferable to use the async functions rather than polling functions when possible.
+	pub fn poll_recv_with_ancillary<'a>(
+		&self,
+		cx: &mut Context,
+		buffer: &mut [u8],
+		ancillary_buffer: &'a mut [u8],
+	) -> Poll<std::io::Result<(MessageInfo, AncillaryMessageReader<'a>)>> {
+		self.poll_recv_vectored_with_ancillary(cx, &mut [IoSliceMut::new(buffer)], ancillary_buffer)
 	}
 
 	/// Try to receive data with ancillary data on the socket from the connected peer without blocking.
@@ -367,6 +418,32 @@ impl UnixSeqpacket {
 		ancillary_buffer: &'a mut [u8],
 	) -> Poll<std::io::Result<(MessageInfo, AncillaryMessageReader<'a>)>> {
 		self.poll_recv_vectored_with_ancillary_internal(cx, buffer, ancillary_buffer, false)
+	}
+
+	/// Try to peek at the next message and its ancillary data on the socket from the connected peer without blocking.
+	///
+	/// Any file descriptors received in the anicallary data will have the `close-on-exec` flag set.
+	/// If the OS supports it, this is done atomically with the reception of the message.
+	/// However, on Illumos and Solaris, the `close-on-exec` flag is set in a separate step after receiving the message.
+	///
+	/// Note that you should always wrap or close any file descriptors received this way.
+	/// If you do not, the received file descriptors will stay open until the process is terminated.
+	///
+	/// Peeking a message with ancillary data may consume or omit it on some platforms. See the
+	/// [type level documentation](UnixSeqpacket) for more information.
+	///
+	/// If there is no data ready yet, the current task is scheduled to wake up when the socket becomes readable.
+	///
+	/// Note that unlike [`Self::peek_with_ancillary`], only the last task calling this function will be woken up.
+	/// For that reason, it is preferable to use the async functions rather than polling functions when possible.
+	#[cfg(any(target_os = "linux", target_os = "android"))]
+	pub fn poll_peek_with_ancillary<'a>(
+		&self,
+		cx: &mut Context,
+		buffer: &mut [u8],
+		ancillary_buffer: &'a mut [u8],
+	) -> Poll<std::io::Result<(MessageInfo, AncillaryMessageReader<'a>)>> {
+		self.poll_peek_vectored_with_ancillary(cx, &mut [IoSliceMut::new(buffer)], ancillary_buffer)
 	}
 
 	/// Try to peek at the next message and its ancillary data on the socket from the connected peer without blocking.
@@ -478,12 +555,58 @@ impl UnixSeqpacket {
 	/// This function is safe to call concurrently from different tasks.
 	/// All calling tasks will try to complete the asynchronous action,
 	/// although the order in which they complete is not guaranteed.
+	pub async fn recv_with_ancillary<'a>(
+		&self,
+		buffer: &mut [u8],
+		ancillary_buffer: &'a mut [u8],
+	) -> std::io::Result<(MessageInfo, AncillaryMessageReader<'a>)> {
+		self.recv_vectored_with_ancillary(&mut [IoSliceMut::new(buffer)], ancillary_buffer)
+			.await
+	}
+
+	/// Receive data with ancillary data on the socket from the connected peer.
+	///
+	/// Any file descriptors received in the anicallary data will have the `close-on-exec` flag set.
+	/// If the OS supports it, this is done atomically with the reception of the message.
+	/// However, on Illumos and Solaris, the `close-on-exec` flag is set in a separate step after receiving the message.
+	///
+	/// Note that you should always wrap or close any file descriptors received this way.
+	/// If you do not, the received file descriptors will stay open until the process is terminated.
+	///
+	/// This function is safe to call concurrently from different tasks.
+	/// All calling tasks will try to complete the asynchronous action,
+	/// although the order in which they complete is not guaranteed.
 	pub async fn recv_vectored_with_ancillary<'a>(
 		&self,
 		buffer: &mut [IoSliceMut<'_>],
 		ancillary_buffer: &'a mut [u8],
 	) -> std::io::Result<(MessageInfo, AncillaryMessageReader<'a>)> {
 		self.recv_vectored_with_ancillary_internal(buffer, ancillary_buffer, false)
+			.await
+	}
+
+	/// Peek at the next message and its ancillary data on the socket from the connected peer.
+	///
+	/// Any file descriptors received in the anicallary data will have the `close-on-exec` flag set.
+	/// If the OS supports it, this is done atomically with the reception of the message.
+	/// However, on Illumos and Solaris, the `close-on-exec` flag is set in a separate step after receiving the message.
+	///
+	/// Note that you should always wrap or close any file descriptors received this way.
+	/// If you do not, the received file descriptors will stay open until the process is terminated.
+	///
+	/// Peeking a message with ancillary data may consume or omit it on some platforms. See the
+	/// [type level documentation](UnixSeqpacket) for more information.
+	///
+	/// This function is safe to call concurrently from different tasks.
+	/// All calling tasks will try to complete the asynchronous action,
+	/// although the order in which they complete is not guaranteed.
+	#[cfg(any(target_os = "linux", target_os = "android"))]
+	pub async fn peek_with_ancillary<'a>(
+		&self,
+		buffer: &mut [u8],
+		ancillary_buffer: &'a mut [u8],
+	) -> std::io::Result<(MessageInfo, AncillaryMessageReader<'a>)> {
+		self.peek_vectored_with_ancillary(&mut [IoSliceMut::new(buffer)], ancillary_buffer)
 			.await
 	}
 

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -61,7 +61,7 @@ impl MessageInfo {
 /// This type exposes methods to peek at the next message to be received.
 /// However, the POSIX standard does not specify how peeking at a seqpacket/datagram affects its ancillary data.
 ///
-/// On Linux and Android, ancillary file descriptors are cloned when peeking,
+/// On Linux and Android, ancillary file descriptors are duplicated when peeking,
 /// so they are not lost to subsequent `peek` or `recv` calls.
 /// This makes it possible to expose [`poll_peek_vectored_with_ancillary`] and [`peek_vectored_with_ancillary`] methods
 /// that have the same ancillary ownership semantics as their `recv` variants.

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -5,6 +5,7 @@ use std::os::raw::{c_int, c_void};
 use std::path::{Path, PathBuf};
 
 use crate::ancillary::{AncillaryMessageReader, AncillaryMessageWriter};
+use crate::MessageInfo;
 
 const SOCKET_FLAGS: c_int = libc::SOCK_CLOEXEC | libc::SOCK_NONBLOCK;
 const SOCKET_TYPE: c_int = libc::SOCK_SEQPACKET | SOCKET_FLAGS;
@@ -169,23 +170,12 @@ pub fn send_msg(
 	}
 }
 
-pub fn recv(socket: &FileDesc, buffer: &mut [u8]) -> std::io::Result<usize> {
-	unsafe {
-		let read = check_size(libc::recv(
-			socket.as_raw_fd(),
-			buffer.as_mut_ptr() as *mut c_void,
-			buffer.len(),
-			RECV_MSG_DEFAULT_FLAGS,
-		))?;
-		Ok(read)
-	}
-}
-
 pub fn recv_msg<'a>(
 	socket: &FileDesc,
 	buffer: &mut [IoSliceMut],
 	ancillary_buffer: &'a mut [u8],
-) -> std::io::Result<(usize, AncillaryMessageReader<'a>)> {
+	peek: bool,
+) -> std::io::Result<(MessageInfo, AncillaryMessageReader<'a>)> {
 	let control_data = match ancillary_buffer.len() {
 		0 => std::ptr::null_mut(),
 		_ => ancillary_buffer.as_mut_ptr() as *mut std::os::raw::c_void,
@@ -211,23 +201,30 @@ pub fn recv_msg<'a>(
 			.map_err(|_| std::io::ErrorKind::InvalidInput)?;
 	}
 
-	let size = unsafe {
+	let peek_flag = if peek { libc::MSG_PEEK } else { 0 };
+	let bytes_read = unsafe {
 		check_size(libc::recvmsg(
 			socket.as_raw_fd(),
 			&mut header as *mut _,
-			RECV_MSG_DEFAULT_FLAGS,
+			RECV_MSG_DEFAULT_FLAGS | peek_flag,
 		))?
 	};
-	let truncated = header.msg_flags & libc::MSG_CTRUNC != 0;
+
+	let msg_info = MessageInfo {
+		bytes_read,
+		truncated: header.msg_flags & libc::MSG_TRUNC != 0,
+		ancillary_truncated: header.msg_flags & libc::MSG_CTRUNC != 0,
+	};
+
 	// This is not a no-op on all platforms.
 	#[allow(clippy::unnecessary_cast)]
 	let length = header.msg_controllen as usize;
-
-	let ancillary_reader = unsafe { AncillaryMessageReader::new(&mut ancillary_buffer[..length], truncated) };
+	let ancillary_reader =
+		unsafe { AncillaryMessageReader::new(&mut ancillary_buffer[..length], msg_info.ancillary_truncated) };
 
 	#[cfg(any(target_os = "illumos", target_os = "solaris"))]
 	post_process_fds(&ancillary_reader);
-	Ok((size, ancillary_reader))
+	Ok((msg_info, ancillary_reader))
 }
 
 // Illumos and solaris do not support MSG_CMSG_CLOEXEC,

--- a/src/ucred.rs
+++ b/src/ucred.rs
@@ -39,44 +39,51 @@ impl UCred {
 			Some(self.pid)
 		}
 	}
+}
 
-	#[cfg(any(target_os = "linux", target_os = "android"))]
-	pub(crate) fn from_scm_creds(raw: crate::ancillary::RawScmCreds) -> UCred {
-		UCred {
-			uid: raw.uid,
-			gid: raw.gid,
-			pid: raw.pid,
+#[cfg(feature = "non-portable")]
+mod non_portable {
+	use super::UCred;
+
+	impl UCred {
+		#[cfg(any(target_os = "linux", target_os = "android"))]
+		pub(crate) fn from_scm_creds(raw: crate::ancillary::RawScmCreds) -> UCred {
+			UCred {
+				uid: raw.uid,
+				gid: raw.gid,
+				pid: raw.pid,
+			}
 		}
-	}
 
-	#[cfg(target_os = "netbsd")]
-	pub(crate) fn from_scm_creds(raw: crate::ancillary::RawScmCreds) -> UCred {
-		UCred {
-			uid: raw.sc_uid,
-			gid: raw.sc_gid,
-			pid: raw.sc_pid,
+		#[cfg(target_os = "netbsd")]
+		pub(crate) fn from_scm_creds(raw: crate::ancillary::RawScmCreds) -> UCred {
+			UCred {
+				uid: raw.sc_uid,
+				gid: raw.sc_gid,
+				pid: raw.sc_pid,
+			}
 		}
-	}
 
-	#[cfg(any(target_os = "linux", target_os = "android"))]
-	pub(crate) fn to_scm_creds(self) -> crate::ancillary::RawScmCreds {
-		crate::ancillary::RawScmCreds {
-			uid: self.uid,
-			gid: self.gid,
-			pid: self.pid,
+		#[cfg(any(target_os = "linux", target_os = "android"))]
+		pub(crate) fn to_scm_creds(self) -> crate::ancillary::RawScmCreds {
+			crate::ancillary::RawScmCreds {
+				uid: self.uid,
+				gid: self.gid,
+				pid: self.pid,
+			}
 		}
-	}
 
-	#[cfg(target_os = "netbsd")]
-	pub(crate) fn to_scm_creds(self) -> crate::ancillary::RawScmCreds {
-		crate::ancillary::RawScmCreds {
-			sc_uid: self.uid,
-			sc_gid: self.gid,
-			sc_pid: self.pid,
-			sc_euid: self.uid,
-			sc_egid: self.gid,
-			sc_ngroups: 0,
-			sc_groups: [],
+		#[cfg(target_os = "netbsd")]
+		pub(crate) fn to_scm_creds(self) -> crate::ancillary::RawScmCreds {
+			crate::ancillary::RawScmCreds {
+				sc_uid: self.uid,
+				sc_gid: self.gid,
+				sc_pid: self.pid,
+				sc_euid: self.uid,
+				sc_egid: self.gid,
+				sc_ngroups: 0,
+				sc_groups: [],
+			}
 		}
 	}
 }

--- a/tests/abstract_namespace.rs
+++ b/tests/abstract_namespace.rs
@@ -49,7 +49,7 @@ async fn address_without_null_byte() {
 
 	let mut buffer = [0u8; 128];
 	assert!(let Ok(msg_info) = server_socket.recv(&mut buffer).await);
-	assert_eq!(msg_info.bytes_read(), 12);
+	assert!(msg_info.bytes_read() == 12);
 	assert!(&buffer[..12] == b"Hello world!");
 }
 
@@ -73,6 +73,6 @@ async fn address_ending_with_null_byte() {
 
 	let mut buffer = [0u8; 128];
 	assert!(let Ok(msg_info) = server_socket.recv(&mut buffer).await);
-	assert_eq!(msg_info.bytes_read(), 12);
+	assert!(msg_info.bytes_read() == 12);
 	assert!(&buffer[..12] == b"Hello world!");
 }

--- a/tests/abstract_namespace.rs
+++ b/tests/abstract_namespace.rs
@@ -48,7 +48,8 @@ async fn address_without_null_byte() {
 	assert!(let Ok(12) = client_socket.send(b"Hello world!").await);
 
 	let mut buffer = [0u8; 128];
-	assert!(let Ok(12) = server_socket.recv(&mut buffer).await);
+	assert!(let Ok(msg_info) = server_socket.recv(&mut buffer).await);
+	assert_eq!(msg_info.bytes_read(), 12);
 	assert!(&buffer[..12] == b"Hello world!");
 }
 
@@ -71,6 +72,7 @@ async fn address_ending_with_null_byte() {
 	assert!(let Ok(12) = client_socket.send(b"Hello world!").await);
 
 	let mut buffer = [0u8; 128];
-	assert!(let Ok(12) = server_socket.recv(&mut buffer).await);
+	assert!(let Ok(msg_info) = server_socket.recv(&mut buffer).await);
+	assert_eq!(msg_info.bytes_read(), 12);
 	assert!(&buffer[..12] == b"Hello world!");
 }

--- a/tests/ancillary_fd_helper/mod.rs
+++ b/tests/ancillary_fd_helper/mod.rs
@@ -21,7 +21,7 @@ pub async fn receive_file_descriptor_socket(file_payload: &[u8], socket_payload:
 
 	// Send the message with file descriptor.
 	assert!(let Ok(n_written) = socket_a.send_vectored_with_ancillary(&[IoSlice::new(socket_payload)], &mut cmsg).await);
-	assert_eq!(n_written, socket_payload.len());
+	assert!(n_written == socket_payload.len());
 
 	// Return the receiving socket from the scope.
 	socket_b
@@ -34,7 +34,7 @@ pub async fn receive_file_descriptor(ancillary_buf: &mut [u8]) -> AncillaryMessa
 
 	let mut read_buf = [0u8; 64];
 	assert!(let Ok((msg_info, cmsg)) = socket.recv_vectored_with_ancillary(&mut [IoSliceMut::new(&mut read_buf)], ancillary_buf).await);
-	assert_eq!(msg_info.bytes_read(), 29);
+	assert!(msg_info.bytes_read() == 29);
 	assert!(&read_buf[..29] == b"Here, have a file descriptor.");
 
 	cmsg

--- a/tests/ancillary_fd_helper/mod.rs
+++ b/tests/ancillary_fd_helper/mod.rs
@@ -5,30 +5,35 @@ use tempfile::tempfile;
 use tokio_seqpacket::ancillary::{AncillaryMessageReader, AncillaryMessageWriter};
 use tokio_seqpacket::UnixSeqpacket;
 
+pub async fn receive_file_descriptor_socket(file_payload: &[u8], socket_payload: &[u8]) -> UnixSeqpacket {
+	// Make a file to send as attachment.
+	assert!(let Ok(mut file) = tempfile());
+	assert!(let Ok(_) = file.write_all(file_payload));
+	assert!(let Ok(()) = file.rewind());
+
+	// Make a pair of connected sockets to send it over.
+	assert!(let Ok((socket_a, socket_b)) = UnixSeqpacket::pair());
+
+	// Prepare an ancillary message and add the file descriptor to it.
+	let mut cmsg = [0; 64];
+	let mut cmsg = AncillaryMessageWriter::new(&mut cmsg);
+	assert!(let Ok(()) = cmsg.add_fds([file.as_fd()]));
+
+	// Send the message with file descriptor.
+	assert!(let Ok(n_written) = socket_a.send_vectored_with_ancillary(&[IoSlice::new(socket_payload)], &mut cmsg).await);
+	assert_eq!(n_written, socket_payload.len());
+
+	// Return the receiving socket from the scope.
+	socket_b
+}
+
+// This function is unused in the `ancillary_fds_peek` test, but used by others.
+#[allow(dead_code)]
 pub async fn receive_file_descriptor(ancillary_buf: &mut [u8]) -> AncillaryMessageReader<'_> {
-	let socket_b = {
-		// Make a file to send as attachment.
-		assert!(let Ok(mut file) = tempfile());
-		assert!(let Ok(_) = file.write_all(b"Wie dit leest is gek."));
-		assert!(let Ok(()) = file.rewind());
-
-		// Make a pair of connected sockets to send it over.
-		assert!(let Ok((socket_a, socket_b)) = UnixSeqpacket::pair());
-
-		// Prepare an ancillary message and add the file descriptor to it.
-		let mut cmsg = [0; 64];
-		let mut cmsg = AncillaryMessageWriter::new(&mut cmsg);
-		assert!(let Ok(()) = cmsg.add_fds([file.as_fd()]));
-
-		// Send the message with file descriptor.
-		assert!(let Ok(29) = socket_a.send_vectored_with_ancillary(&[IoSlice::new(b"Here, have a file descriptor.")], &mut cmsg).await);
-
-		// Return the receiving socket from the scope.
-		socket_b
-	};
+	let socket = receive_file_descriptor_socket(b"Wie dit leest is gek.", b"Here, have a file descriptor.").await;
 
 	let mut read_buf = [0u8; 64];
-	assert!(let Ok((msg_info, cmsg)) = socket_b.recv_vectored_with_ancillary(&mut [IoSliceMut::new(&mut read_buf)], ancillary_buf).await);
+	assert!(let Ok((msg_info, cmsg)) = socket.recv_vectored_with_ancillary(&mut [IoSliceMut::new(&mut read_buf)], ancillary_buf).await);
 	assert_eq!(msg_info.bytes_read(), 29);
 	assert!(&read_buf[..29] == b"Here, have a file descriptor.");
 

--- a/tests/ancillary_fd_helper/mod.rs
+++ b/tests/ancillary_fd_helper/mod.rs
@@ -28,7 +28,8 @@ pub async fn receive_file_descriptor(ancillary_buf: &mut [u8]) -> AncillaryMessa
 	};
 
 	let mut read_buf = [0u8; 64];
-	assert!(let Ok((29, cmsg)) = socket_b.recv_vectored_with_ancillary(&mut [IoSliceMut::new(&mut read_buf)], ancillary_buf).await);
+	assert!(let Ok((msg_info, cmsg)) = socket_b.recv_vectored_with_ancillary(&mut [IoSliceMut::new(&mut read_buf)], ancillary_buf).await);
+	assert_eq!(msg_info.bytes_read(), 29);
 	assert!(&read_buf[..29] == b"Here, have a file descriptor.");
 
 	cmsg

--- a/tests/ancillary_fds_peek.rs
+++ b/tests/ancillary_fds_peek.rs
@@ -1,0 +1,49 @@
+#![cfg(any(target_os = "linux", target_os = "android"))]
+
+use assert2::assert;
+use std::io::{IoSliceMut, Read, Seek};
+use tokio_seqpacket::ancillary::{AncillaryMessageReader, OwnedAncillaryMessage};
+
+mod ancillary_fd_helper;
+use ancillary_fd_helper::receive_file_descriptor_socket;
+
+#[tokio::test]
+async fn peek_fd() {
+	// Create a socket that receives a file descriptor
+	let socket = receive_file_descriptor_socket(b"Content", b"Hello world!").await;
+
+	let mut read_buf = [0u8; 64];
+	let mut ancillary_buf = [0u8; 64];
+
+	fn assert_cmsg(cmsg: AncillaryMessageReader<'_>) {
+		// Check that we got exactly one control message containing file descriptors.
+		let mut messages = cmsg.into_messages();
+		assert!(let Some(OwnedAncillaryMessage::FileDescriptors(mut fds)) = messages.next());
+		assert!(let None = messages.next());
+
+		// Check that we got exactly one file descriptor in the first control message.
+		assert!(let Some(fd) = fds.next());
+		assert!(let None = fds.next());
+
+		// Check that we can retrieve the message from the attached file.
+		let mut file = std::fs::File::from(fd);
+		let mut contents = Vec::new();
+		assert!(let Ok(_) = file.read_to_end(&mut contents));
+		assert!(contents == b"Content");
+
+		// Seek back to the start of the file for the next run.
+		assert!(let Ok(_) = file.rewind());
+	}
+
+	// We should be able to peek at the message (and thus get FDs) twice.
+	for _ in 0..2 {
+		assert!(let Ok((msg_info, cmsg)) = socket.peek_vectored_with_ancillary(&mut [IoSliceMut::new(&mut read_buf)], &mut ancillary_buf).await);
+		assert_eq!(msg_info.bytes_read(), 12);
+		assert_cmsg(cmsg)
+	}
+
+	// We should be able to receive the message after peeking at it.
+	assert!(let Ok((msg_info, cmsg)) = socket.recv_vectored_with_ancillary(&mut [IoSliceMut::new(&mut read_buf)], &mut ancillary_buf).await);
+	assert_eq!(msg_info.bytes_read(), 12);
+	assert_cmsg(cmsg)
+}

--- a/tests/ancillary_fds_peek.rs
+++ b/tests/ancillary_fds_peek.rs
@@ -1,4 +1,4 @@
-#![cfg(any(target_os = "linux", target_os = "android"))]
+#![cfg(all(feature = "non-portable", any(target_os = "linux", target_os = "android")))]
 
 use assert2::assert;
 use std::io::{IoSliceMut, Read, Seek};

--- a/tests/ancillary_fds_peek.rs
+++ b/tests/ancillary_fds_peek.rs
@@ -38,12 +38,12 @@ async fn peek_fd() {
 	// We should be able to peek at the message (and thus get FDs) twice.
 	for _ in 0..2 {
 		assert!(let Ok((msg_info, cmsg)) = socket.peek_vectored_with_ancillary(&mut [IoSliceMut::new(&mut read_buf)], &mut ancillary_buf).await);
-		assert_eq!(msg_info.bytes_read(), 12);
+		assert!(msg_info.bytes_read() == 12);
 		assert_cmsg(cmsg)
 	}
 
 	// We should be able to receive the message after peeking at it.
 	assert!(let Ok((msg_info, cmsg)) = socket.recv_vectored_with_ancillary(&mut [IoSliceMut::new(&mut read_buf)], &mut ancillary_buf).await);
-	assert_eq!(msg_info.bytes_read(), 12);
+	assert!(msg_info.bytes_read() == 12);
 	assert_cmsg(cmsg)
 }

--- a/tests/listener.rs
+++ b/tests/listener.rs
@@ -17,8 +17,8 @@ async fn unix_seqpacket_listener() {
 				assert!(let Ok(peer) = listener.accept().await);
 				assert!(let Ok(_) = peer.send(b"Hello!").await);
 				let mut buf = [0u8; 128];
-				assert!(let Ok(len) = peer.recv(&mut buf).await);
-				assert!(&buf[..len] == b"Goodbye!");
+				assert!(let Ok(msg_info) = peer.recv(&mut buf).await);
+				assert!(&buf[..msg_info.bytes_read()] == b"Goodbye!");
 			}
 		}
 	});
@@ -26,8 +26,8 @@ async fn unix_seqpacket_listener() {
 	for _ in 0..2 {
 		assert!(let Ok(peer) = UnixSeqpacket::connect(&path).await);
 		let mut buf = [0u8; 128];
-		assert!(let Ok(len) = peer.recv(&mut buf).await);
-		assert!(&buf[..len] == b"Hello!");
+		assert!(let Ok(msg_info) = peer.recv(&mut buf).await);
+		assert!(&buf[..msg_info.bytes_read()] == b"Hello!");
 		assert!(let Ok(_) = peer.send(b"Goodbye!").await);
 	}
 

--- a/tests/multiple_fds.rs
+++ b/tests/multiple_fds.rs
@@ -31,7 +31,8 @@ pub async fn receive_file_descriptor(ancillary_buf: &mut [u8]) -> AncillaryMessa
 	};
 
 	let mut read_buf = [0u8; 64];
-	assert!(let Ok((29, cmsg)) = socket_b.recv_vectored_with_ancillary(&mut [IoSliceMut::new(&mut read_buf)], ancillary_buf).await);
+	assert!(let Ok((msg_info, cmsg)) = socket_b.recv_vectored_with_ancillary(&mut [IoSliceMut::new(&mut read_buf)], ancillary_buf).await);
+	assert_eq!(msg_info.bytes_read(), 29);
 	assert!(&read_buf[..29] == b"Here, have a file descriptor.");
 
 	cmsg

--- a/tests/multiple_fds.rs
+++ b/tests/multiple_fds.rs
@@ -32,7 +32,7 @@ pub async fn receive_file_descriptor(ancillary_buf: &mut [u8]) -> AncillaryMessa
 
 	let mut read_buf = [0u8; 64];
 	assert!(let Ok((msg_info, cmsg)) = socket_b.recv_vectored_with_ancillary(&mut [IoSliceMut::new(&mut read_buf)], ancillary_buf).await);
-	assert_eq!(msg_info.bytes_read(), 29);
+	assert!(msg_info.bytes_read() == 29);
 	assert!(&read_buf[..29] == b"Here, have a file descriptor.");
 
 	cmsg

--- a/tests/raw_fd.rs
+++ b/tests/raw_fd.rs
@@ -15,6 +15,6 @@ async fn send_recv() {
 
 	let mut buffer = [0u8; 128];
 	assert!(let Ok(msg_info) = b.recv(&mut buffer).await);
-	assert_eq!(msg_info.bytes_read(), 12);
+	assert!(msg_info.bytes_read() == 12);
 	assert!(&buffer[..12] == b"Hello world!");
 }

--- a/tests/raw_fd.rs
+++ b/tests/raw_fd.rs
@@ -14,6 +14,7 @@ async fn send_recv() {
 	assert!(let Ok(12) = a.send(b"Hello world!").await);
 
 	let mut buffer = [0u8; 128];
-	assert!(let Ok(12) = b.recv(&mut buffer).await);
+	assert!(let Ok(msg_info) = b.recv(&mut buffer).await);
+	assert_eq!(msg_info.bytes_read(), 12);
 	assert!(&buffer[..12] == b"Hello world!");
 }

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -8,7 +8,8 @@ async fn send_recv() {
 	assert!(let Ok(12) = a.send(b"Hello world!").await);
 
 	let mut buffer = [0u8; 128];
-	assert!(let Ok(12) = b.recv(&mut buffer).await);
+	assert!(let Ok(msg_info) = b.recv(&mut buffer).await);
+	assert_eq!(msg_info.bytes_read(), 12);
 	assert!(&buffer[..12] == b"Hello world!");
 }
 
@@ -22,9 +23,11 @@ async fn record_boundaries() {
 	// Having sent two messages, we recv should return twice, with only a single message each
 	// time.
 	let mut buffer = [0u8; 128];
-	assert!(let Ok(12) = b.recv(&mut buffer).await);
+	assert!(let Ok(msg_info) = b.recv(&mut buffer).await);
+	assert_eq!(msg_info.bytes_read(), 12);
 	assert!(&buffer[..12] == b"Hello world!");
-	assert!(let Ok(12) = b.recv(&mut buffer).await);
+	assert!(let Ok(msg_info) = b.recv(&mut buffer).await);
+	assert_eq!(msg_info.bytes_read(), 12);
 	assert!(&buffer[..12] == b"Byebye world");
 }
 
@@ -55,7 +58,8 @@ fn send_recv_out_of_order() {
 
 		let mut buffer = [0u8; 128];
 		ABOUT_TO_READ.store(true, Ordering::Relaxed);
-		assert!(let Ok(12) = b.recv(&mut buffer).await);
+		assert!(let Ok(msg_info) = b.recv(&mut buffer).await);
+		assert_eq!(msg_info.bytes_read(), 12);
 		assert!(&buffer[..12] == b"Hello world!");
 
 		assert!(let Ok(()) = task.await);
@@ -79,12 +83,13 @@ async fn send_recv_vectored() {
 	let mut space = [0u8; 1];
 	let mut world = [0u8; 5];
 	let mut punct = [0u8; 1];
-	assert!(let Ok(12) = b.recv_vectored(&mut [
+	assert!(let Ok(msg_info) = b.recv_vectored(&mut [
 		IoSliceMut::new(&mut hello),
 		IoSliceMut::new(&mut space),
 		IoSliceMut::new(&mut world),
 		IoSliceMut::new(&mut punct),
 	]).await);
+	assert_eq!(msg_info.bytes_read(), 12);
 
 	assert!(&hello == b"Hello");
 	assert!(&space == b" ");
@@ -106,12 +111,12 @@ fn echo_loop() {
 			let mut buf = vec![0u8; 2048];
 			loop {
 				println!("waiting for next request");
-				assert!(let Ok(n_received) = server.recv(&mut buf).await);
-				println!("received: {}", String::from_utf8_lossy(&buf[..n_received]));
-				if n_received == 0 {
+				assert!(let Ok(msg_info) = server.recv(&mut buf).await);
+				println!("received: {}", String::from_utf8_lossy(&buf[..msg_info.bytes_read()]));
+				if msg_info.bytes_read() == 0 {
 					break;
 				}
-				assert!(let Ok(_) = server.send(&buf[..n_received]).await);
+				assert!(let Ok(_) = server.send(&buf[..msg_info.bytes_read()]).await);
 			}
 		});
 		let client = tokio::task::spawn(async move {
@@ -120,8 +125,8 @@ fn echo_loop() {
 				assert!(let Ok(n_sent) = client.send(message.as_bytes()).await);
 				assert!(n_sent == message.len());
 				let mut buf = vec![0u8; 1024];
-				assert!(let Ok(n_received) = client.recv(&mut buf).await);
-				assert!(message.as_bytes() == &buf[..n_received]);
+				assert!(let Ok(msg_info) = client.recv(&mut buf).await);
+				assert!(message.as_bytes() == &buf[..msg_info.bytes_read()]);
 			}
 		});
 
@@ -155,7 +160,8 @@ fn multiple_waiters() {
 			async move {
 				let mut buffer = [0u8; 12];
 				assert!(written.load(Ordering::Relaxed) == 0); // Double check that the test will cause recv() to park the current task.
-				assert!(let Ok(12) = a.recv(&mut buffer).await);
+				assert!(let Ok(msg_info) = a.recv(&mut buffer).await);
+				assert_eq!(msg_info.bytes_read(), 12);
 				assert!(&buffer == b"Hello world!");
 				received.fetch_add(1, Ordering::Relaxed);
 			}
@@ -168,7 +174,8 @@ fn multiple_waiters() {
 			async move {
 				let mut buffer = [0u8; 12];
 				assert!(written.load(Ordering::Relaxed) == 0); // Double check that the test will cause recv() to park the current task.
-				assert!(let Ok(12) = a.recv(&mut buffer).await);
+				assert!(let Ok(msg_info) = a.recv(&mut buffer).await);
+				assert_eq!(msg_info.bytes_read(), 12);
 				assert!(&buffer == b"Hello world!");
 				received.fetch_add(1, Ordering::Relaxed);
 			}

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -9,7 +9,7 @@ async fn send_recv() {
 
 	let mut buffer = [0u8; 128];
 	assert!(let Ok(msg_info) = b.recv(&mut buffer).await);
-	assert_eq!(msg_info.bytes_read(), 12);
+	assert!(msg_info.bytes_read() == 12);
 	assert!(!msg_info.truncated());
 	assert!(&buffer[..12] == b"Hello world!");
 }
@@ -22,9 +22,9 @@ async fn recv_partial() {
 
 	let mut buffer = [0u8; 5];
 	assert!(let Ok(msg_info) = b.recv(&mut buffer).await);
-	assert_eq!(msg_info.bytes_read(), 5);
+	assert!(msg_info.bytes_read() == 5);
 	assert!(msg_info.truncated());
-	assert_eq!(&buffer, b"Hello");
+	assert!(&buffer == b"Hello");
 }
 
 /// Test a simple send and peek call.
@@ -38,14 +38,14 @@ async fn send_peek() {
 	// Peeking should not consume the message, so do it twice
 	for _ in 0..2 {
 		assert!(let Ok(msg_info) = b.peek(&mut buffer).await);
-		assert_eq!(msg_info.bytes_read(), 12);
+		assert!(msg_info.bytes_read() == 12);
 		assert!(!msg_info.truncated());
 		assert!(&buffer[..12] == b"Hello world!");
 	}
 
 	// We should still able to receive the message after peeking
 	assert!(let Ok(msg_info) = b.recv(&mut buffer).await);
-	assert_eq!(msg_info.bytes_read(), 12);
+	assert!(msg_info.bytes_read() == 12);
 	assert!(!msg_info.truncated());
 	assert!(&buffer[..12] == b"Hello world!");
 }
@@ -58,13 +58,13 @@ async fn peek_partial() {
 
 	let mut buffer = [0u8; 128];
 	assert!(let Ok(msg_info) = b.peek(&mut buffer[..5]).await);
-	assert_eq!(msg_info.bytes_read(), 5);
+	assert!(msg_info.bytes_read() == 5);
 	assert!(msg_info.truncated());
 	assert!(&buffer[..5] == b"Hello");
 
 	// We should still able to receive the full message after peeking
 	assert!(let Ok(msg_info) = b.recv(&mut buffer).await);
-	assert_eq!(msg_info.bytes_read(), 12);
+	assert!(msg_info.bytes_read() == 12);
 	assert!(!msg_info.truncated());
 	assert!(&buffer[..12] == b"Hello world!");
 }
@@ -80,10 +80,10 @@ async fn record_boundaries() {
 	// time.
 	let mut buffer = [0u8; 128];
 	assert!(let Ok(msg_info) = b.recv(&mut buffer).await);
-	assert_eq!(msg_info.bytes_read(), 12);
+	assert!(msg_info.bytes_read() == 12);
 	assert!(&buffer[..12] == b"Hello world!");
 	assert!(let Ok(msg_info) = b.recv(&mut buffer).await);
-	assert_eq!(msg_info.bytes_read(), 12);
+	assert!(msg_info.bytes_read() == 12);
 	assert!(&buffer[..12] == b"Byebye world");
 }
 
@@ -115,7 +115,7 @@ fn send_recv_out_of_order() {
 		let mut buffer = [0u8; 128];
 		ABOUT_TO_READ.store(true, Ordering::Relaxed);
 		assert!(let Ok(msg_info) = b.recv(&mut buffer).await);
-		assert_eq!(msg_info.bytes_read(), 12);
+		assert!(msg_info.bytes_read() == 12);
 		assert!(&buffer[..12] == b"Hello world!");
 
 		assert!(let Ok(()) = task.await);
@@ -145,7 +145,7 @@ async fn send_recv_vectored() {
 		IoSliceMut::new(&mut world),
 		IoSliceMut::new(&mut punct),
 	]).await);
-	assert_eq!(msg_info.bytes_read(), 12);
+	assert!(msg_info.bytes_read() == 12);
 
 	assert!(&hello == b"Hello");
 	assert!(&space == b" ");
@@ -179,7 +179,7 @@ async fn send_peek_vectored() {
 			IoSliceMut::new(&mut world),
 			IoSliceMut::new(&mut punct),
 		]).await);
-		assert_eq!(msg_info.bytes_read(), 12);
+		assert!(msg_info.bytes_read() == 12);
 
 		assert!(&hello == b"Hello");
 		assert!(&space == b" ");
@@ -190,7 +190,7 @@ async fn send_peek_vectored() {
 	// We should still able to receive the message after peeking
 	let mut buffer = [0u8; 12];
 	assert!(let Ok(msg_info) = b.recv(&mut buffer).await);
-	assert_eq!(msg_info.bytes_read(), 12);
+	assert!(msg_info.bytes_read() == 12);
 	assert!(&buffer[..12] == b"Hello world!");
 }
 
@@ -258,7 +258,7 @@ fn multiple_waiters() {
 				let mut buffer = [0u8; 12];
 				assert!(written.load(Ordering::Relaxed) == 0); // Double check that the test will cause recv() to park the current task.
 				assert!(let Ok(msg_info) = a.recv(&mut buffer).await);
-				assert_eq!(msg_info.bytes_read(), 12);
+				assert!(msg_info.bytes_read() == 12);
 				assert!(&buffer == b"Hello world!");
 				received.fetch_add(1, Ordering::Relaxed);
 			}
@@ -272,7 +272,7 @@ fn multiple_waiters() {
 				let mut buffer = [0u8; 12];
 				assert!(written.load(Ordering::Relaxed) == 0); // Double check that the test will cause recv() to park the current task.
 				assert!(let Ok(msg_info) = a.recv(&mut buffer).await);
-				assert_eq!(msg_info.bytes_read(), 12);
+				assert!(msg_info.bytes_read() == 12);
 				assert!(&buffer == b"Hello world!");
 				received.fetch_add(1, Ordering::Relaxed);
 			}

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -10,6 +10,62 @@ async fn send_recv() {
 	let mut buffer = [0u8; 128];
 	assert!(let Ok(msg_info) = b.recv(&mut buffer).await);
 	assert_eq!(msg_info.bytes_read(), 12);
+	assert!(!msg_info.truncated());
+	assert!(&buffer[..12] == b"Hello world!");
+}
+
+/// Test that receiving a message partially sets the truncated flag.
+#[tokio::test]
+async fn recv_partial() {
+	assert!(let Ok((a, b)) = UnixSeqpacket::pair());
+	assert!(let Ok(12) = a.send(b"Hello world!").await);
+
+	let mut buffer = [0u8; 5];
+	assert!(let Ok(msg_info) = b.recv(&mut buffer).await);
+	assert_eq!(msg_info.bytes_read(), 5);
+	assert!(msg_info.truncated());
+	assert_eq!(&buffer, b"Hello");
+}
+
+/// Test a simple send and peek call.
+#[tokio::test]
+async fn send_peek() {
+	assert!(let Ok((a, b)) = UnixSeqpacket::pair());
+	assert!(let Ok(12) = a.send(b"Hello world!").await);
+
+	let mut buffer = [0u8; 128];
+
+	// Peeking should not consume the message, so do it twice
+	for _ in 0..2 {
+		assert!(let Ok(msg_info) = b.peek(&mut buffer).await);
+		assert_eq!(msg_info.bytes_read(), 12);
+		assert!(!msg_info.truncated());
+		assert!(&buffer[..12] == b"Hello world!");
+	}
+
+	// We should still able to receive the message after peeking
+	assert!(let Ok(msg_info) = b.recv(&mut buffer).await);
+	assert_eq!(msg_info.bytes_read(), 12);
+	assert!(!msg_info.truncated());
+	assert!(&buffer[..12] == b"Hello world!");
+}
+
+/// Test peeking a portion of a message with a small buffer.
+#[tokio::test]
+async fn peek_partial() {
+	assert!(let Ok((a, b)) = UnixSeqpacket::pair());
+	assert!(let Ok(12) = a.send(b"Hello world!").await);
+
+	let mut buffer = [0u8; 128];
+	assert!(let Ok(msg_info) = b.peek(&mut buffer[..5]).await);
+	assert_eq!(msg_info.bytes_read(), 5);
+	assert!(msg_info.truncated());
+	assert!(&buffer[..5] == b"Hello");
+
+	// We should still able to receive the full message after peeking
+	assert!(let Ok(msg_info) = b.recv(&mut buffer).await);
+	assert_eq!(msg_info.bytes_read(), 12);
+	assert!(!msg_info.truncated());
 	assert!(&buffer[..12] == b"Hello world!");
 }
 
@@ -95,6 +151,47 @@ async fn send_recv_vectored() {
 	assert!(&space == b" ");
 	assert!(&world == b"world");
 	assert!(&punct == b"!");
+}
+
+/// Test a simple send_vectored and peek_vectored call.
+#[tokio::test]
+async fn send_peek_vectored() {
+	use std::io::{IoSlice, IoSliceMut};
+
+	assert!(let Ok((a, b)) = UnixSeqpacket::pair());
+	assert!(let Ok(12) = a.send_vectored(&[
+		IoSlice::new(b"Hello"),
+		IoSlice::new(b" "),
+		IoSlice::new(b"world"),
+		IoSlice::new(b"!"),
+	]).await);
+
+	let mut hello = [0u8; 5];
+	let mut space = [0u8; 1];
+	let mut world = [0u8; 5];
+	let mut punct = [0u8; 1];
+
+	// Peeking should not consume the message
+	for _ in 0..2 {
+		assert!(let Ok(msg_info) = b.peek_vectored(&mut [
+			IoSliceMut::new(&mut hello),
+			IoSliceMut::new(&mut space),
+			IoSliceMut::new(&mut world),
+			IoSliceMut::new(&mut punct),
+		]).await);
+		assert_eq!(msg_info.bytes_read(), 12);
+
+		assert!(&hello == b"Hello");
+		assert!(&space == b" ");
+		assert!(&world == b"world");
+		assert!(&punct == b"!");
+	}
+
+	// We should still able to receive the message after peeking
+	let mut buffer = [0u8; 12];
+	assert!(let Ok(msg_info) = b.recv(&mut buffer).await);
+	assert_eq!(msg_info.bytes_read(), 12);
+	assert!(&buffer[..12] == b"Hello world!");
 }
 
 #[test]

--- a/tests/split.rs
+++ b/tests/split.rs
@@ -15,9 +15,9 @@ async fn send_recv() {
 
 	let mut buffer = [0u8; 128];
 
-	assert!(let Ok(len) = read_b.recv(&mut buffer).await);
-	assert!(&buffer[..len] == b"Hello B!");
+	assert!(let Ok(msg_info) = read_b.recv(&mut buffer).await);
+	assert!(&buffer[..msg_info.bytes_read()] == b"Hello B!");
 
-	assert!(let Ok(len) = read_a.recv(&mut buffer).await);
-	assert!(&buffer[..len] == b"Hello A!");
+	assert!(let Ok(msg_info) = read_a.recv(&mut buffer).await);
+	assert!(&buffer[..msg_info.bytes_read()] == b"Hello A!");
 }


### PR DESCRIPTION
Note: This PR grew a little beyond it's original scope, so let me know if you'd prefer it split. Might be a good idea to review commit by commit.

- (Breaking change) Receive methods now return a `MessageInfo` struct with getters for `bytes_read`, `truncated` and `ancillary_truncated`.

- Adds support for peeking at the first seqpacket message in the receive queue. Peeking at the data only is supported on all OSes, with a note that ancillary data may still be consumed when peeking on some of them (the POSIX standard is very much unclear on this). Peeking at ancillary data is feature gated to Linux and Android, where peeked FDs are cloned.

  Unfortunately this limitation is necessary as the behavior can go from unintuitive to straight up buggy on other platforms. For example, I've tried to support FreeBSD, where ancillary FDs are not cloned when peeking (so you'd expect that simply not closing the fds or exposing `into_messages` would be fine), but a subsequent `recv` of the message added an extra FD to the buffer with value `-2047`, which is just nonsense.

- Adds non-vectored ancillary send/receive/peek methods. If it's considered redundant idm removing them, but it's nice to have IMO.

- Since we now have a few methods on `UnixSeqpacket` that are OS-gated, enable `feature(doc_cfg)` on docs.rs builds to make that information clear to the reader.