### PR TITLE
Remove old note about wrapping file descriptors.

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -381,9 +381,6 @@ impl UnixSeqpacket {
 	/// If the OS supports it, this is done atomically with the reception of the message.
 	/// However, on Illumos and Solaris, the `close-on-exec` flag is set in a separate step after receiving the message.
 	///
-	/// Note that you should always wrap or close any file descriptors received this way.
-	/// If you do not, the received file descriptors will stay open until the process is terminated.
-	///
 	/// If there is no data ready yet, the current task is scheduled to wake up when the socket becomes readable.
 	///
 	/// Note that unlike [`Self::recv_with_ancillary`], only the last task calling this function will be woken up.
@@ -403,9 +400,6 @@ impl UnixSeqpacket {
 	/// If the OS supports it, this is done atomically with the reception of the message.
 	/// However, on Illumos and Solaris, the `close-on-exec` flag is set in a separate step after receiving the message.
 	///
-	/// Note that you should always wrap or close any file descriptors received this way.
-	/// If you do not, the received file descriptors will stay open until the process is terminated.
-	///
 	/// If there is no data ready yet, the current task is scheduled to wake up when the socket becomes readable.
 	///
 	/// Note that unlike [`Self::recv_vectored_with_ancillary`], only the last task calling this function will be woken up.
@@ -424,9 +418,6 @@ impl UnixSeqpacket {
 	/// Any file descriptors received in the anicallary data will have the `close-on-exec` flag set.
 	/// If the OS supports it, this is done atomically with the reception of the message.
 	/// However, on Illumos and Solaris, the `close-on-exec` flag is set in a separate step after receiving the message.
-	///
-	/// Note that you should always wrap or close any file descriptors received this way.
-	/// If you do not, the received file descriptors will stay open until the process is terminated.
 	///
 	/// Any objects in the ancillary data are duplicated.
 	/// They will be received again in subsequent calls to any peek or recv function.
@@ -451,9 +442,6 @@ impl UnixSeqpacket {
 	/// Any file descriptors received in the anicallary data will have the `close-on-exec` flag set.
 	/// If the OS supports it, this is done atomically with the reception of the message.
 	/// However, on Illumos and Solaris, the `close-on-exec` flag is set in a separate step after receiving the message.
-	///
-	/// Note that you should always wrap or close any file descriptors received this way.
-	/// If you do not, the received file descriptors will stay open until the process is terminated.
 	///
 	/// Any objects in the ancillary data are duplicated.
 	/// They will be received again in subsequent calls to any peek or recv function.
@@ -550,9 +538,6 @@ impl UnixSeqpacket {
 	/// If the OS supports it, this is done atomically with the reception of the message.
 	/// However, on Illumos and Solaris, the `close-on-exec` flag is set in a separate step after receiving the message.
 	///
-	/// Note that you should always wrap or close any file descriptors received this way.
-	/// If you do not, the received file descriptors will stay open until the process is terminated.
-	///
 	/// This function is safe to call concurrently from different tasks.
 	/// All calling tasks will try to complete the asynchronous action,
 	/// although the order in which they complete is not guaranteed.
@@ -571,9 +556,6 @@ impl UnixSeqpacket {
 	/// If the OS supports it, this is done atomically with the reception of the message.
 	/// However, on Illumos and Solaris, the `close-on-exec` flag is set in a separate step after receiving the message.
 	///
-	/// Note that you should always wrap or close any file descriptors received this way.
-	/// If you do not, the received file descriptors will stay open until the process is terminated.
-	///
 	/// This function is safe to call concurrently from different tasks.
 	/// All calling tasks will try to complete the asynchronous action,
 	/// although the order in which they complete is not guaranteed.
@@ -591,9 +573,6 @@ impl UnixSeqpacket {
 	/// Any file descriptors received in the anicallary data will have the `close-on-exec` flag set.
 	/// If the OS supports it, this is done atomically with the reception of the message.
 	/// However, on Illumos and Solaris, the `close-on-exec` flag is set in a separate step after receiving the message.
-	///
-	/// Note that you should always wrap or close any file descriptors received this way.
-	/// If you do not, the received file descriptors will stay open until the process is terminated.
 	///
 	/// Any objects in the ancillary data are duplicated.
 	/// They will be received again in subsequent calls to any peek or recv function.
@@ -617,9 +596,6 @@ impl UnixSeqpacket {
 	/// Any file descriptors received in the anicallary data will have the `close-on-exec` flag set.
 	/// If the OS supports it, this is done atomically with the reception of the message.
 	/// However, on Illumos and Solaris, the `close-on-exec` flag is set in a separate step after receiving the message.
-	///
-	/// Note that you should always wrap or close any file descriptors received this way.
-	/// If you do not, the received file descriptors will stay open until the process is terminated.
 	///
 	/// Any objects in the ancillary data are duplicated.
 	/// They will be received again in subsequent calls to any peek or recv function.


### PR DESCRIPTION
The API already ensures ownership of file descriptors is managed properly.