### PR TITLE
Add UnixSeqpacket::connect_blocking()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 main:
   * Allow passing in file descriptors and ucreds through a fixed size iterator.
   * Allow peeking at the next incoming message (will loose ancillary data on some platforms).
+  * Add `UnixSeqpacket::connect_blocking(...)` function.
 
 v0.8.2 - 2026-05-14:
   * Make full capacity available for Linux abstract socket paths (was short one byte).

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,9 +1,5 @@
 hard_tabs = true
 tab_spaces = 4
 max_width = 120
-imports_layout = "HorizontalVertical"
 match_block_trailing_comma = true
-overflow_delimited_expr = true
-reorder_impl_items = true
-unstable_features = true
 use_field_init_shorthand = true

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -60,7 +60,7 @@ impl UnixSeqpacketListener {
 	/// The `backlog` parameter is used to determine the size of connection queue.
 	/// See `man 3 listen` for more information.
 	pub fn bind_with_backlog<P: AsRef<Path>>(address: P, backlog: c_int) -> std::io::Result<Self> {
-		let socket = sys::local_seqpacket_socket()?;
+		let socket = sys::local_seqpacket_socket_non_blocking()?;
 		sys::bind(&socket, address)?;
 		sys::listen(&socket, backlog)?;
 		Self::new(socket)

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -116,7 +116,7 @@ impl UnixSeqpacket {
 
 	/// Connect a new seqpacket socket to the given address.
 	pub async fn connect<P: AsRef<Path>>(address: P) -> std::io::Result<Self> {
-		let socket = sys::local_seqpacket_socket()?;
+		let socket = sys::local_seqpacket_socket_non_blocking()?;
 		if let Err(e) = sys::connect(&socket, address) {
 			if e.kind() != std::io::ErrorKind::WouldBlock {
 				return Err(e);
@@ -126,6 +126,29 @@ impl UnixSeqpacket {
 		let socket = Self::new(socket)?;
 		socket.io.writable().await?.retain_ready();
 		Ok(socket)
+	}
+
+	/// Connect a new seqpacket socket to the given address, blocking until the connection is established.
+	///
+	/// Note that the socket has to be registered with the tokio [`Runtime`].
+	/// This means that the function can not be used outside of a tokio runtime, event though it is blocking.
+	///
+	/// [`Runtime`]: https://docs.rs/tokio/1/tokio/runtime/struct.Runtime.html
+	pub fn connect_blocking<P: AsRef<Path>>(address: P) -> std::io::Result<Self> {
+		let mut socket = sys::local_seqpacket_socket_blocking()?;
+		if let Err(e) = sys::connect(&socket, address) {
+			if e.kind() != std::io::ErrorKind::WouldBlock {
+				return Err(e);
+			}
+		}
+
+		// SAFETY: We just created the socket in this scope,
+		// no other thread can soundly be be modifying its flags right now.
+		unsafe {
+			sys::set_non_blocking(&mut socket, true)?;
+		}
+
+		Self::new(socket)
 	}
 
 	/// Create a pair of connected seqpacket sockets.

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -16,9 +16,16 @@ const RECV_MSG_DEFAULT_FLAGS: c_int = libc::MSG_NOSIGNAL;
 #[cfg(not(any(target_os = "illumos", target_os = "solaris")))]
 const RECV_MSG_DEFAULT_FLAGS: c_int = libc::MSG_NOSIGNAL | libc::MSG_CMSG_CLOEXEC;
 
-pub fn local_seqpacket_socket() -> std::io::Result<FileDesc> {
+pub fn local_seqpacket_socket_non_blocking() -> std::io::Result<FileDesc> {
 	unsafe {
 		let fd = check(libc::socket(libc::AF_UNIX, SOCKET_TYPE, 0))?;
+		Ok(FileDesc::from_raw_fd(fd))
+	}
+}
+
+pub fn local_seqpacket_socket_blocking() -> std::io::Result<FileDesc> {
+	unsafe {
+		let fd = check(libc::socket(libc::AF_UNIX, SOCKET_TYPE & !libc::SOCK_NONBLOCK, 0))?;
 		Ok(FileDesc::from_raw_fd(fd))
 	}
 }
@@ -29,6 +36,23 @@ pub fn local_seqpacket_pair() -> std::io::Result<(FileDesc, FileDesc)> {
 		check(libc::socketpair(libc::AF_UNIX, SOCKET_TYPE, 0, fds.as_mut_ptr()))?;
 		Ok((FileDesc::from_raw_fd(fds[0]), FileDesc::from_raw_fd(fds[1])))
 	}
+}
+
+/// Set the underlying object of a file descriptor in blocking or non-blocking mode.
+///
+/// SAFETY: This is not an atomic operation.
+/// You must ensure that no other thread is modiying open file flags at the same time, or modifications from one thread may be lost.
+/// Since file descriptors can be duplicated, even taking `&mut FileDesc` is not enough to prevent this race conditions.
+pub unsafe fn set_non_blocking(fd: &mut FileDesc, non_blocking: bool) -> std::io::Result<()> {
+	unsafe {
+		let old_flags = check(libc::fcntl(fd.as_raw_fd(), libc::F_GETFL))?;
+		let new_flags = match non_blocking {
+			true => old_flags | libc::O_NONBLOCK,
+			false => old_flags & !libc::O_NONBLOCK,
+		};
+		check(libc::fcntl(fd.as_raw_fd(), libc::F_SETFL, new_flags))?;
+	}
+	Ok(())
 }
 
 pub fn connect<P: AsRef<Path>>(socket: &FileDesc, address: P) -> std::io::Result<()> {

--- a/tests/listener.rs
+++ b/tests/listener.rs
@@ -33,3 +33,43 @@ async fn unix_seqpacket_listener() {
 
 	assert!(let Ok(()) = server_task.await);
 }
+
+/// Test that we can do a blocking connect on the listener.
+#[tokio::test]
+async fn connect_blocking() {
+	let dir = tempdir().unwrap();
+	let path = dir.path().join("listener.sock");
+
+	let server_task = tokio::spawn({
+		assert!(let Ok(mut listener) = UnixSeqpacketListener::bind(&path));
+		assert!(let Ok(local_address) = listener.local_addr());
+		assert!(local_address == path);
+		async move {
+			for _ in 0..2 {
+				assert!(let Ok(peer) = listener.accept().await);
+				assert!(let Ok(_) = peer.send(b"Hello!").await);
+				let mut buf = [0u8; 128];
+				assert!(let Ok(msg_info) = peer.recv(&mut buf).await);
+				assert!(&buf[..msg_info.bytes_read()] == b"Goodbye!");
+			}
+		}
+	});
+
+	for _ in 0..2 {
+		let peer = tokio::task::spawn_blocking({
+			let path = path.clone();
+			move || {
+				assert!(let Ok(peer) = UnixSeqpacket::connect_blocking(&path));
+				peer
+			}
+		})
+		.await
+		.unwrap();
+		let mut buf = [0u8; 128];
+		assert!(let Ok(msg_info) = peer.recv(&mut buf).await);
+		assert!(&buf[..msg_info.bytes_read()] == b"Hello!");
+		assert!(let Ok(_) = peer.send(b"Goodbye!").await);
+	}
+
+	assert!(let Ok(()) = server_task.await);
+}


### PR DESCRIPTION
A bit of a niche function, but it allows you to create a seqpacket socket in a non-async function. However, it can still only be used if the tokio runtime is active, since the socket must be registered with the runtime.